### PR TITLE
[WIP] Implement interface to provide the resolver an initial state

### DIFF
--- a/news/1.feature.rst
+++ b/news/1.feature.rst
@@ -1,0 +1,1 @@
+Support resolving based on an existing state, instead of always from ground zero. This allows the user to perform a differential resolution that only makes minimal changes to a given dataset.

--- a/news/3.behavior.rst
+++ b/news/3.behavior.rst
@@ -1,0 +1,1 @@
+The `State` class is not part of the public interface, and is a “real” object instead of a tuple subclass.

--- a/src/resolvelib/__init__.py
+++ b/src/resolvelib/__init__.py
@@ -1,6 +1,8 @@
 __all__ = [
     '__version__',
-    'AbstractProvider', 'BaseReporter', 'Resolver',
+
+    'AbstractProvider', 'BaseReporter', 'Resolver', 'State', 'DirectedGraph',
+
     'NoVersionsAvailable', 'RequirementsConflicted',
     'ResolutionError', 'ResolutionImpossible', 'ResolutionTooDeep',
 ]
@@ -10,7 +12,10 @@ __version__ = '0.2.1.dev0'
 
 from .providers import AbstractProvider
 from .reporters import BaseReporter
+from .resolvers import Resolver, State
+from .structs import DirectedGraph
+
 from .resolvers import (
     NoVersionsAvailable, RequirementsConflicted,
-    Resolver, ResolutionError, ResolutionImpossible, ResolutionTooDeep,
+    ResolutionError, ResolutionImpossible, ResolutionTooDeep,
 )

--- a/src/resolvelib/structs.py
+++ b/src/resolvelib/structs.py
@@ -6,6 +6,14 @@ class DirectedGraph(object):
         self._forwards = {}     # <key> -> Set[<key>]
         self._backwards = {}    # <key> -> Set[<key>]
 
+    def __repr__(self):
+        vcount = len(self._vertices)
+        ecount = sum(len(es) for es in self._forwards.values())
+        return "<DirectedGraph: {vc} {vt}, {ec} {et}>".format(
+            vc=vcount, vt="vertex" if vcount == 1 else "vertices",
+            ec=ecount, et="edge" if ecount == 1 else "edges",
+        )
+
     def __iter__(self):
         return iter(self._vertices)
 
@@ -14,6 +22,12 @@ class DirectedGraph(object):
 
     def __contains__(self, key):
         return key in self._vertices
+
+    @classmethod
+    def from_vertices(cls, vertices):
+        instance = cls()
+        instance._vertices = set(vertices)
+        return instance
 
     def copy(self):
         """Return a shallow copy of this graph.


### PR DESCRIPTION
This would allow add, remove, and upgrade semantics. Fix #1.

* [x] Enable passing in a state object.
* [x] Public state interface.
* [ ] Review internals to be resillient of slightly out-of-sync mapping and graph
* [ ] Resolver should clean up the graph to purge dead subtrees, and maping to remove unneeded pins after resolution (or maybe after each round?).
* [ ] `add` semantic
* [ ] `remove` semantic
* [ ] `upgrade` semantic