### PR TITLE
Remove reporting callbacks added in 0.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Features
 --------
 
 - Add new reporting callbacks `adding_requirements`, `adding_candidate`, and `replacing_candidate` to report progress in requirement pinning.  `#2 <https://github.com/sarugaku/resolvelib/issues/2>`_
-  
+
 
 Bug Fixes
 ---------

--- a/news/6.feature.rst
+++ b/news/6.feature.rst
@@ -1,0 +1,1 @@
+Remove reporting callbacks `adding_requirements`, `adding_candidate`, and `replacing_candidate` added in 0.2.1. These are not useful, and it’s better to remove them while we can.

--- a/src/resolvelib/reporters.py
+++ b/src/resolvelib/reporters.py
@@ -11,20 +11,6 @@ class BaseReporter(object):
         The index is zero-based.
         """
 
-    def adding_requirements(self, requirements):
-        """Called before requirements are being added.
-
-        The requirements are not necessarily new.
-        """
-
-    def adding_candidate(self, candidate):
-        """Called before a candidate is being used to pin a requirement.
-        """
-
-    def replacing_candidate(self, current, replacement):
-        """Called before a candidate is being replaced by another as the pin.
-        """
-
     def ending_round(self, index, state):
         """Called before each round of resolution ends.
 

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -166,16 +166,13 @@ class Resolution(object):
         except RequirementsConflicted:
             self._criteria = backup
             return None
-        self._r.adding_requirements(dependencies)
         return contributed
 
     def _pin_candidate(self, name, criterion, candidate, child_names):
         try:
             self.state.graph.remove(name)
         except KeyError:
-            self._r.adding_candidate(candidate)
-        else:
-            self._r.replacing_candidate(self.state.mapping[name], candidate)
+            pass
         self.state.mapping[name] = candidate
         self.state.graph.add(name)
         for parent in criterion.iter_parent():


### PR DESCRIPTION
They are not useful at all. Remove them before anyone actually uses them.