### PR TITLE
Add AbstractResolver class and introduce (and reorganize) 'abstract' subpackage

### DIFF
--- a/src/resolvelib/__init__.py
+++ b/src/resolvelib/__init__.py
@@ -1,6 +1,6 @@
 __all__ = [
     '__version__',
-    'AbstractProvider', 'BaseReporter', 'Resolver',
+    'AbstractProvider', 'AbstractResolver', 'BaseReporter', 'Resolver',
     'NoVersionsAvailable', 'RequirementsConflicted',
     'ResolutionError', 'ResolutionImpossible', 'ResolutionTooDeep',
 ]
@@ -8,7 +8,7 @@ __all__ = [
 __version__ = '0.2.3.dev0'
 
 
-from .providers import AbstractProvider
+from .providers import AbstractProvider, AbstractResolver
 from .reporters import BaseReporter
 from .resolvers import (
     NoVersionsAvailable, RequirementsConflicted,

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -1,5 +1,5 @@
 class AbstractProvider(object):
-    """Delegate class to provide requirment interface for the resolver.
+    """Delegate class to provide requirement interface for the resolver.
     """
     def identify(self, dependency):
         """Given a dependency, return an identifier for it.
@@ -64,7 +64,7 @@ class AbstractProvider(object):
     def is_satisfied_by(self, requirement, candidate):
         """Whether the given requirement can be satisfied by a candidate.
 
-        A boolean should be retuened to indicate whether `candidate` is a
+        A boolean should be returned to indicate whether `candidate` is a
         viable solution to the requirement.
         """
         raise NotImplementedError
@@ -74,5 +74,46 @@ class AbstractProvider(object):
 
         This should return a collection of requirements that `candidate`
         specifies as its dependencies.
+        """
+        raise NotImplementedError
+
+
+class AbstractResolver(object):
+    """The thing that performs the actual resolution work.
+    """
+    base_exception = Exception
+
+    def __init__(self, provider, reporter):
+        self.provider = provider
+        self.reporter = reporter
+
+    def resolve(self, requirements, **kwargs):
+        """Take a collection of constraints, spit out the resolution result.
+
+        Parameters
+        ----------
+        requirements : Collection
+            A collection of constraints
+        kwargs : optional
+            Additional keyword arguments that subclasses may accept.
+
+        Raises
+        ------
+        self.base_exception
+            Any raised exception is guaranteed to be a subclass of
+            self.base_exception. The string representation of an exception
+            should be human readable and provide context for why it occurred.
+
+        Returns
+        -------
+        retval : object
+            A representation of the final resolution state. It can be any object
+            with a `mapping` attribute that is a Mapping. Other attributes can
+            be used to provide resolver-specific information.
+
+            The `mapping` attribute MUST be key-value pair is an identifier of a
+            requirement (as returned by the provider's `identify` method) mapped
+            to the resolved candidate (chosen from the return value of the
+            provider's `find_matches` method).
         """
         raise NotImplementedError

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -1,5 +1,6 @@
 import collections
 
+from .providers import AbstractResolver
 from .structs import DirectedGraph
 
 
@@ -8,14 +9,19 @@ RequirementInformation = collections.namedtuple('RequirementInformation', [
 ])
 
 
-class NoVersionsAvailable(Exception):
+class ResolverException(Exception):
+    """A base class for all exceptions raised by this module.
+    """
+
+
+class NoVersionsAvailable(ResolverException):
     def __init__(self, requirement, parent):
         super(NoVersionsAvailable, self).__init__()
         self.requirement = requirement
         self.parent = parent
 
 
-class RequirementsConflicted(Exception):
+class RequirementsConflicted(ResolverException):
     def __init__(self, criterion):
         super(RequirementsConflicted, self).__init__()
         self.criterion = criterion
@@ -68,7 +74,7 @@ class Criterion(object):
         return type(self)(candidates, infos)
 
 
-class ResolutionError(Exception):
+class ResolutionError(ResolverException):
     pass
 
 
@@ -251,12 +257,10 @@ class Resolution(object):
         raise ResolutionTooDeep(max_rounds)
 
 
-class Resolver(object):
+class Resolver(AbstractResolver):
     """The thing that performs the actual resolution work.
     """
-    def __init__(self, provider, reporter):
-        self.provider = provider
-        self.reporter = reporter
+    base_exception = ResolverException
 
     def resolve(self, requirements, max_rounds=20):
         """Take a collection of constraints, spit out the resolution result.


### PR DESCRIPTION
@techalchemy This is what I was suggesting -- adding an 'AbstractResolver'.

This would basically make resolvelib's resolver-like interface implemented separately (and provide different semantics like PubGrub-based resolution or Molinillo-based resolution).
