### PR TITLE
Ensure the pinned candidate is actually satisfying

### DIFF
--- a/src/resolvelib/__init__.py
+++ b/src/resolvelib/__init__.py
@@ -3,6 +3,7 @@ __all__ = [
     "AbstractProvider",
     "AbstractResolver",
     "BaseReporter",
+    "InconsistentCandidate",
     "Resolver",
     "RequirementsConflicted",
     "ResolutionError",
@@ -16,6 +17,7 @@ __version__ = "0.2.3.dev0"
 from .providers import AbstractProvider, AbstractResolver
 from .reporters import BaseReporter
 from .resolvers import (
+    InconsistentCandidate,
     RequirementsConflicted,
     Resolver,
     ResolutionError,

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -1,0 +1,42 @@
+import pytest
+
+from resolvelib import (
+    AbstractProvider,
+    BaseReporter,
+    InconsistentCandidate,
+    Resolver,
+)
+
+
+def test_candidate_inconsistent_error():
+    requirement = "foo"
+    candidate = "bar"
+
+    class Provider(AbstractProvider):
+        def identify(self, d):
+            assert d is requirement or d is candidate
+            return d
+
+        def get_preference(self, *_):
+            return 0
+
+        def get_dependencies(self, _):
+            return []
+
+        def find_matches(self, r):
+            assert r is requirement
+            return [candidate]
+
+        def is_satisfied_by(self, r, c):
+            assert r is requirement
+            assert c is candidate
+            return False
+
+    resolver = Resolver(Provider(), BaseReporter())
+
+    with pytest.raises(InconsistentCandidate) as ctx:
+        resolver.resolve([requirement])
+
+    assert str(ctx.value) == "Provided candidate 'bar' does not satisfy 'foo'"
+    assert ctx.value.candidate is candidate
+    assert list(ctx.value.criterion.iter_requirement()) == [requirement]


### PR DESCRIPTION
A faulty provider may have its `find_matches()` return candidates that don’t actually return True for `is_satisfied_by()`. This will cause errors difficult to debug down the resolution process, so we make sure to check it at pin time, and raise an error to tell the provider to fix things.

WIP, I want to add a test to make sure we raise this correctly.

Ref #33.