### PR TITLE
Avoid using exception for control flow in backtracking

### DIFF
--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -110,13 +110,15 @@ class Criterion(object):
 
     def excluded_of(self, candidate):
         """Build a new instance from this, but excluding specified candidate.
+
+        Returns the new instance, or None if we still have no valid candidates.
         """
         incompats = list(self.incompatibilities)
         incompats.append(candidate)
         candidates = [c for c in self.candidates if c != candidate]
-        criterion = type(self)(candidates, list(self.information), incompats)
         if not candidates:
-            raise RequirementsConflicted(criterion)
+            return None
+        criterion = type(self)(candidates, list(self.information), incompats)
         return criterion
 
 
@@ -253,10 +255,9 @@ class Resolution(object):
             name, candidate = self._states.pop().mapping.popitem()
             self._push_new_state()
 
-            try:
-                # Mark the retracted candidate as incompatible.
-                criterion = self.state.criteria[name].excluded_of(candidate)
-            except RequirementsConflicted:
+            # Mark the retracted candidate as incompatible.
+            criterion = self.state.criteria[name].excluded_of(candidate)
+            if criterion is None:
                 # This state still does not work. Try the still previous state.
                 continue
             self.state.criteria[name] = criterion


### PR DESCRIPTION
The current backtracking code uses a `RequirementsConflicted` exception to report back to the backtracker that removing one candidate didn't fix the issue. While it's not an unreasonable interpretation of the exception, the control flow is entirely local between `_backtrack` and `excluded_of`. As a result, it makes it harder to reason about the global uses of the `RequirementsConflicted` exception.

This PR changes the control flow to use a `None` return value rather than an exception.

This is (hopefully) the first of a series of PRs to clean up the resolver's exception handling, to make it easier for client code to provide useful diagnostics to the user when resolution fails.