### PR TITLE
Introduce iter_matches() to replace find_matches()

### DIFF
--- a/examples/pypi_wheel_provider.py
+++ b/examples/pypi_wheel_provider.py
@@ -123,19 +123,20 @@ class PyPIProvider(ExtrasProvider):
     def get_preference(self, resolution, candidates, information):
         return len(candidates)
 
-    def find_matches(self, requirement):
+    def iter_matches(self, requirements):
         candidates = []
-        name = requirement.name
-        extras = requirement.extras
+        name = requirements[0].name
+        extras = requirements[0].extras
 
         # Need to pass the extras to the search, so they
         # are added to the candidate at creation - we
         # treat candidates as immutable once created.
         for c in get_project_from_pypi(name, extras):
             version = c.version
-            if version in requirement.specifier:
+            if all(version in r.specifier for r in requirements):
                 candidates.append(c)
-        return candidates
+        for c in reversed(candidates):
+            yield c
 
     def is_satisfied_by(self, requirement, candidate):
         if canonicalize_name(requirement.name) != candidate.name:

--- a/examples/pypi_wheel_provider.py
+++ b/examples/pypi_wheel_provider.py
@@ -126,8 +126,9 @@ class PyPIProvider(ExtrasProvider):
 
     def iter_matches(self, requirements):
         assert requirements, "resolver promises at least one requirement"
-        assert not any(r.extras for r in requirements[1:]), \
-            "extras not supported in this example"
+        assert not any(
+            r.extras for r in requirements[1:]
+        ), "extras not supported in this example"
 
         name = canonicalize_name(requirements[0].name)
 

--- a/examples/pypi_wheel_provider.py
+++ b/examples/pypi_wheel_provider.py
@@ -1,9 +1,10 @@
-import platform
+from email.message import EmailMessage
+from email.parser import BytesParser
 from io import BytesIO
+from operator import attrgetter
+from platform import python_version
 from urllib.parse import urlparse
 from zipfile import ZipFile
-from email.parser import BytesParser
-from email.message import EmailMessage
 
 import requests
 import html5lib
@@ -14,7 +15,7 @@ from packaging.utils import canonicalize_name
 
 from extras_provider import ExtrasProvider
 
-PYTHON_VERSION = Version(platform.python_version())
+PYTHON_VERSION = Version(python_version())
 
 
 class Candidate:
@@ -124,18 +125,21 @@ class PyPIProvider(ExtrasProvider):
         return len(candidates)
 
     def iter_matches(self, requirements):
-        candidates = []
-        name = requirements[0].name
-        extras = requirements[0].extras
+        assert requirements, "resolver promises at least one requirement"
+        assert not any(r.extras for r in requirements[1:]), \
+            "extras not supported in this example"
+
+        name = canonicalize_name(requirements[0].name)
 
         # Need to pass the extras to the search, so they
         # are added to the candidate at creation - we
         # treat candidates as immutable once created.
-        for c in get_project_from_pypi(name, extras):
+        candidates = []
+        for c in get_project_from_pypi(name, set()):
             version = c.version
             if all(version in r.specifier for r in requirements):
                 candidates.append(c)
-        for c in reversed(candidates):
+        for c in sorted(candidates, key=attrgetter("version"), reverse=True):
             yield c
 
     def is_satisfied_by(self, requirement, candidate):

--- a/examples/pypi_wheel_provider.py
+++ b/examples/pypi_wheel_provider.py
@@ -124,7 +124,7 @@ class PyPIProvider(ExtrasProvider):
     def get_preference(self, resolution, candidates, information):
         return len(candidates)
 
-    def iter_matches(self, requirements):
+    def find_matches(self, requirements):
         assert requirements, "resolver promises at least one requirement"
         assert not any(
             r.extras for r in requirements[1:]
@@ -140,8 +140,7 @@ class PyPIProvider(ExtrasProvider):
             version = c.version
             if all(version in r.specifier for r in requirements):
                 candidates.append(c)
-        for c in sorted(candidates, key=attrgetter("version"), reverse=True):
-            yield c
+        return sorted(candidates, key=attrgetter("version"), reverse=True)
 
     def is_satisfied_by(self, requirement, candidate):
         if canonicalize_name(requirement.name) != candidate.name:

--- a/examples/reporter_demo.py
+++ b/examples/reporter_demo.py
@@ -50,14 +50,10 @@ class Provider(resolvelib.AbstractProvider):
     def get_preference(self, resolution, candidates, information):
         return len(candidates)
 
-    def find_matches(self, requirement):
-        deps = [
-            (n, v)
-            for (n, v) in sorted(self.candidates, reverse=True)
-            if n == requirement[0] and v in requirement[1]
-        ]
-        deps.sort()
-        return deps
+    def iter_matches(self, requirements):
+        for n, v in sorted(self.candidates, reverse=True):
+            if all(n == r[0] and v in r[1] for r in requirements):
+                yield (n, v)
 
     def is_satisfied_by(self, requirement, candidate):
         assert candidate[0] == requirement[0]

--- a/examples/reporter_demo.py
+++ b/examples/reporter_demo.py
@@ -50,7 +50,7 @@ class Provider(resolvelib.AbstractProvider):
     def get_preference(self, resolution, candidates, information):
         return len(candidates)
 
-    def iter_matches(self, requirements):
+    def find_matches(self, requirements):
         for n, v in sorted(self.candidates, reverse=True):
             if all(n == r[0] and v in r[1] for r in requirements):
                 yield (n, v)

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,20 +8,20 @@ author_email = uranusjr@gmail.com
 long_description = file: README.rst
 license = ISC License
 keywords =
-    dependency
-    resolution
+	dependency
+	resolution
 classifier =
-    Development Status :: 3 - Alpha
-    Intended Audience :: Developers
-    License :: OSI Approved :: ISC License (ISCL)
-    Operating System :: OS Independent
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 3
-    Topic :: Software Development :: Libraries :: Python Modules
+	Development Status :: 3 - Alpha
+	Intended Audience :: Developers
+	License :: OSI Approved :: ISC License (ISCL)
+	Operating System :: OS Independent
+	Programming Language :: Python :: 2
+	Programming Language :: Python :: 3
+	Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
 package_dir =
-    = src
+	= src
 packages = find:
 include_package_data = true
 zip_safe = false
@@ -31,19 +31,19 @@ where = src
 
 [options.extras_require]
 examples =
-    html5lib
-    packaging
-    requests
+	html5lib
+	packaging
+	requests
 lint =
 	black
 	flake8
 test =
-    commentjson
-    packaging
-    pytest
+	commentjson
+	packaging
+	pytest
 release =
 	setl
-    towncrier
+	towncrier
 
 [bdist_wheel]
 universal = 1
@@ -51,8 +51,8 @@ universal = 1
 [flake8]
 max-line-length = 80
 exclude =
-    .git,
-    .venvs,
-    __pycache__,
-    build,
-    dist,
+	.git,
+	.venvs,
+	__pycache__,
+	build,
+	dist,

--- a/src/resolvelib/compat/collections_abc.py
+++ b/src/resolvelib/compat/collections_abc.py
@@ -1,0 +1,6 @@
+__all__ = ["Sequence"]
+
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -49,16 +49,16 @@ class AbstractProvider(object):
         raise NotImplementedError
 
     def iter_matches(self, requirements):
-        """Find all possible candidates that satisfy all given requirements.
+        """Find all possible candidates that satisfy the given requirements.
 
         This should try to get candidates based on the requirements' types.
         For VCS, local, and archive requirements, the one-and-only match is
         returned, and for a "named" requirement, the index(es) should be
         consulted to find concrete candidates for this requirement.
 
-        :param requirements: A collection of requirements to filter out
-            candidates from. All requirements are guarenteed to have the
-            same identifier. The collection is never empty.
+        :param requirements: A collection of requirements which all of the the
+            returned candidates must match. All requirements are guarenteed to
+            have the same identifier. The collection is never empty.
         :returns: An iterator that generates candidates by preference order,
             e.g. the most preferred candidate should come first.
         """

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -48,7 +48,7 @@ class AbstractProvider(object):
         """
         raise NotImplementedError
 
-    def iter_matches(self, requirements):
+    def find_matches(self, requirements):
         """Find all possible candidates that satisfy the given requirements.
 
         This should try to get candidates based on the requirements' types.
@@ -59,8 +59,8 @@ class AbstractProvider(object):
         :param requirements: A collection of requirements which all of the the
             returned candidates must match. All requirements are guarenteed to
             have the same identifier. The collection is never empty.
-        :returns: An iterator that generates candidates by preference order,
-            e.g. the most preferred candidate should come first.
+        :returns: An iterable that orders candidates by preference, e.g. the
+            most preferred candidate should come first.
         """
         raise NotImplementedError
 

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -57,7 +57,7 @@ class AbstractProvider(object):
         consulted to find concrete candidates for this requirement.
 
         :param requirements: A collection of requirements which all of the the
-            returned candidates must match. All requirements are guarenteed to
+            returned candidates must match. All requirements are guaranteed to
             have the same identifier. The collection is never empty.
         :returns: An iterable that orders candidates by preference, e.g. the
             most preferred candidate should come first.

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -48,17 +48,19 @@ class AbstractProvider(object):
         """
         raise NotImplementedError
 
-    def find_matches(self, requirement):
-        """Find all possible candidates that satisfy a requirement.
+    def iter_matches(self, requirements):
+        """Find all possible candidates that satisfy all given requirements.
 
-        This should try to get candidates based on the requirement's type.
+        This should try to get candidates based on the requirements' types.
         For VCS, local, and archive requirements, the one-and-only match is
         returned, and for a "named" requirement, the index(es) should be
         consulted to find concrete candidates for this requirement.
 
-        The returned candidates should be sorted by reversed preference, e.g.
-        the most preferred should be LAST. This is done so list-popping can be
-        as efficient as possible.
+        :param requirements: A collection of requirements to filter out
+            candidates from. All requirements are guarenteed to have the
+            same identifier. The collection is never empty.
+        :returns: An iterator that generates candidates by preference order,
+            e.g. the most preferred candidate should come first.
         """
         raise NotImplementedError
 

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -1,5 +1,6 @@
 import collections
 
+from .compat import collections_abc
 from .providers import AbstractResolver
 from .structs import DirectedGraph
 
@@ -77,7 +78,9 @@ class Criterion(object):
     def from_requirement(cls, provider, requirement, parent):
         """Build an instance from a requirement.
         """
-        candidates = list(provider.iter_matches([requirement]))
+        candidates = provider.find_matches([requirement])
+        if not isinstance(candidates, collections_abc.Sequence):
+            candidates = list(candidates)
         criterion = cls(
             candidates=candidates,
             information=[RequirementInformation(requirement, parent)],
@@ -98,7 +101,9 @@ class Criterion(object):
         """
         infos = list(self.information)
         infos.append(RequirementInformation(requirement, parent))
-        candidates = list(provider.iter_matches([r for r, _ in infos]))
+        candidates = provider.find_matches([r for r, _ in infos])
+        if not isinstance(candidates, collections_abc.Sequence):
+            candidates = list(candidates)
         criterion = type(self)(candidates, infos, list(self.incompatibilities))
         if not candidates:
             raise RequirementsConflicted(criterion)
@@ -224,7 +229,7 @@ class Resolution(object):
             # Check the newly-pinned candidate actually works. This should
             # always pass under normal circumstances, but in the case of a
             # faulty provider, we will raise an error to notify the implementer
-            # to fix iter_matches() and/or is_satisfied_by().
+            # to fix find_matches() and/or is_satisfied_by().
             satisfied = all(
                 self._p.is_satisfied_by(r, candidate)
                 for r in criterion.iter_requirement()

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -106,14 +106,14 @@ class CocoaPodsInputProvider(AbstractProvider):
     def get_preference(self, resolution, candidates, information):
         return len(candidates)
 
-    def _iter_matches(self, requirement):
+    def _iter_matches(self, name, requirements):
         try:
-            data = self.index[requirement.name]
+            data = self.index[name]
         except KeyError:
             return
         for entry in data:
             version = packaging.version.parse(entry["version"])
-            if version not in requirement.spec:
+            if any(version not in r.spec for r in requirements):
                 continue
             # Some fixtures incorrectly set dependencies to an empty list.
             dependencies = entry["dependencies"] or {}
@@ -123,13 +123,18 @@ class CocoaPodsInputProvider(AbstractProvider):
             ]
             yield Candidate(entry["name"], version, dependencies)
 
-    def find_matches(self, requirement):
-        mapping = {c.ver: c for c in self._iter_matches(requirement)}
-        try:
-            version = self.pinned_versions[requirement.name]
-        except KeyError:
-            return sorted(mapping.values(), key=operator.attrgetter("ver"))
-        return [mapping.pop(version)]
+    def iter_matches(self, requirements):
+        name = requirements[0].name
+        candidates = sorted(
+            self._iter_matches(name, requirements),
+            key=operator.attrgetter("ver"),
+            reverse=True,
+        )
+        pinned = self.pinned_versions.get(name)
+        for c in candidates:
+            if pinned is not None and c.ver != pinned:
+                continue
+            yield c
 
     def is_satisfied_by(self, requirement, candidate):
         return candidate.ver in requirement.spec

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -123,7 +123,7 @@ class CocoaPodsInputProvider(AbstractProvider):
             ]
             yield Candidate(entry["name"], version, dependencies)
 
-    def iter_matches(self, requirements):
+    def find_matches(self, requirements):
         name = requirements[0].name
         candidates = sorted(
             self._iter_matches(name, requirements),

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -77,7 +77,7 @@ class PythonInputProvider(AbstractProvider):
                 name=name, version=version, extras=extras,
             )
 
-    def iter_matches(self, requirements):
+    def find_matches(self, requirements):
         name = packaging.utils.canonicalize_name(requirements[0].name)
         candidates = sorted(
             (c for c in self._iter_matches(name, requirements)),

--- a/tests/functional/swift-package-manager/test_resolvers_swift.py
+++ b/tests/functional/swift-package-manager/test_resolvers_swift.py
@@ -97,7 +97,7 @@ class SwiftInputProvider(AbstractProvider):
             preference = _calculate_preference(ver)
             yield (preference, Candidate(container, version))
 
-    def iter_matches(self, requirements):
+    def find_matches(self, requirements):
         matches = sorted(
             self._iter_matches(requirements),
             key=operator.itemgetter(0),

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -23,8 +23,8 @@ def test_candidate_inconsistent_error():
         def get_dependencies(self, _):
             return []
 
-        def find_matches(self, r):
-            assert r is requirement
+        def iter_matches(self, rs):
+            assert rs[0] is requirement
             return [candidate]
 
         def is_satisfied_by(self, r, c):

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -23,7 +23,7 @@ def test_candidate_inconsistent_error():
         def get_dependencies(self, _):
             return []
 
-        def iter_matches(self, rs):
+        def find_matches(self, rs):
             assert len(rs) == 1 and rs[0] is requirement
             return [candidate]
 

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -24,7 +24,7 @@ def test_candidate_inconsistent_error():
             return []
 
         def iter_matches(self, rs):
-            assert rs[0] is requirement
+            assert len(rs) == 1 and rs[0] is requirement
             return [candidate]
 
         def is_satisfied_by(self, r, c):


### PR DESCRIPTION
WIP, fix #48.

I immediately found a problem with my previous `find_all_matches(identifier)` approach: direct URL requirements. The idea of “all” matches is wrong by itself, since there is no universal set of candidates for a givan identifier.

The approach presented here instead simply presents all requirements known to the resolver at a given point, and ask the provider to return candidates that match all of them. This avoids the universal set problem (every candidate discovery is bounded by at least one requirement).

A side effect is this makes the provider a bit more difficult to implement without hitting the finder over and over again. We probably need to implement some kind of memoisation so multiple searches for the package only hit an index once.