### PR TITLE
Better reporter demo

### DIFF
--- a/examples/reporter_demo.py
+++ b/examples/reporter_demo.py
@@ -4,14 +4,24 @@ from packaging.version import Version
 
 import resolvelib
 
-spec = """\
-A 1.0.0
-    B >= 1.0.0
-    C >= 2.0.0
-B 1.0.0
-C 1.0.0
-C 2.0.0
-C 3.0.0
+spec = """
+first 1.0.0
+    second == 1.0.0
+first 2.0.0
+    second == 2.0.0
+    third == 1.0.0
+first 3.0.0
+    second == 3.0.0
+    third == 2.0.0
+second 1.0.0
+    third == 1.0.0
+second 2.0.0
+    third == 2.0.0
+second 3.0.0
+    third == 3.0.0
+third 1.0.0
+third 2.0.0
+third 3.0.0
 """
 
 
@@ -113,7 +123,7 @@ if __name__ == "__main__":
     from pprint import pprint
     provider = Provider(spec.splitlines())
 
-    root_reqs = [Requirement("A", SpecifierSet())]
+    root_reqs = [Requirement("first", SpecifierSet())]
 
     resolver = resolvelib.Resolver(provider, Reporter())
     result = resolver.resolve(root_reqs)


### PR DESCRIPTION
The output of running reporter_demo now looks like:

```
  adding_requirement(Requirement(first), None)
starting()
starting_round(0)
  adding_requirement(Requirement(second==3.0.0), Candidate(first, 3.0.0))
  adding_requirement(Requirement(third==2.0.0), Candidate(first, 3.0.0))
  pinning(Candidate(first, 3.0.0))
ending_round(0, ...)
starting_round(1)
  adding_requirement(Requirement(third==3.0.0), Candidate(second, 3.0.0))
  backtracking(Candidate(first, 3.0.0))
ending_round(1, ...)
starting_round(2)
  adding_requirement(Requirement(second==2.0.0), Candidate(first, 2.0.0))
  adding_requirement(Requirement(third==1.0.0), Candidate(first, 2.0.0))
  pinning(Candidate(first, 2.0.0))
ending_round(2, ...)
starting_round(3)
  adding_requirement(Requirement(third==2.0.0), Candidate(second, 2.0.0))
  backtracking(Candidate(first, 2.0.0))
ending_round(3, ...)
starting_round(4)
  adding_requirement(Requirement(second==1.0.0), Candidate(first, 1.0.0))
  pinning(Candidate(first, 1.0.0))
ending_round(4, ...)
starting_round(5)
  adding_requirement(Requirement(third==1.0.0), Candidate(second, 1.0.0))
  pinning(Candidate(second, 1.0.0))
ending_round(5, ...)
starting_round(6)
  pinning(Candidate(third, 1.0.0))
ending_round(6, ...)
starting_round(7)
ending(...)
{'first': Candidate(first, 1.0.0),
 'second': Candidate(second, 1.0.0),
 'third': Candidate(third, 1.0.0)}
```

I think this is a nice bit of improvement to the example.