### PR TITLE
Drop the overloading of the "dependency" term

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,10 +84,3 @@ An intention to acquire a needed package, i.e. an "abstract requirement". A
 "dependency", if not clarified otherwise, also refers to this concept.
 
 A Requirement should specify two things: a Package, and a Specifier.
-
-
-Dependency
-----------
-
-A dependency can be either a requirement, or a candidate. In implementations
-you can treat it as the parent class and/or a protocol of the two.

--- a/examples/extras_provider.py
+++ b/examples/extras_provider.py
@@ -25,8 +25,8 @@ class ExtrasProvider(AbstractProvider):
     """A provider that handles extras.
     """
 
-    def get_extras_for(self, dependency):
-        """Given a dependency, return its extras.
+    def get_extras_for(self, requirement_or_candidate):
+        """Given a requirement or candidate, return its extras.
 
         The extras should be a hashable value.
         """
@@ -39,9 +39,9 @@ class ExtrasProvider(AbstractProvider):
         """
         raise NotImplementedError
 
-    def identify(self, dependency):
-        base = super(ExtrasProvider, self).identify(dependency)
-        extras = self.get_extras_for(dependency)
+    def identify(self, requirement_or_candidate):
+        base = super(ExtrasProvider, self).identify(requirement_or_candidate)
+        extras = self.get_extras_for(requirement_or_candidate)
         if extras:
             return (base, extras)
         else:

--- a/examples/pypi_wheel_provider.py
+++ b/examples/pypi_wheel_provider.py
@@ -111,12 +111,12 @@ def get_metadata_for_wheel(url):
 
 
 class PyPIProvider(ExtrasProvider):
-    def identify(self, dependency):
-        return canonicalize_name(dependency.name)
+    def identify(self, requirement_or_candidate):
+        return canonicalize_name(requirement_or_candidate.name)
 
-    def get_extras_for(self, dependency):
+    def get_extras_for(self, requirement_or_candidate):
         # Extras is a set, which is not hashable
-        return tuple(sorted(dependency.extras))
+        return tuple(sorted(requirement_or_candidate.extras))
 
     def get_base_requirement(self, candidate):
         return Requirement("{}=={}".format(candidate.name, candidate.version))

--- a/examples/reporter_demo.py
+++ b/examples/reporter_demo.py
@@ -69,8 +69,8 @@ class Provider(resolvelib.AbstractProvider):
     def __init__(self, index):
         self.candidates = read_spec(index)
 
-    def identify(self, dependency):
-        return dependency[0]
+    def identify(self, requirement_or_candidate):
+        return requirement_or_candidate.name
 
     def get_preference(self, resolution, candidates, information):
         return len(candidates)

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -2,13 +2,13 @@ class AbstractProvider(object):
     """Delegate class to provide requirement interface for the resolver.
     """
 
-    def identify(self, dependency):
-        """Given a dependency, return an identifier for it.
+    def identify(self, requirement_or_candidate):
+        """Given a requirement or candidate, return an identifier for it.
 
-        This is used in many places to identify the dependency, e.g. whether
-        two requirements should have their specifier parts merged, whether
-        two specifications would conflict with each other (because they the
-        same name but different versions).
+        This is used in many places to identify a requirement or candidate,
+        e.g. whether two requirements should have their specifier parts merged,
+        whether two candidates would conflict with each other (because they
+        have same name but different versions).
         """
         raise NotImplementedError
 

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -100,8 +100,8 @@ class CocoaPodsInputProvider(AbstractProvider):
         self.expected_resolution = dict(_iter_resolved(case_data["resolved"]))
         self.expected_conflicts = set(case_data["conflicts"])
 
-    def identify(self, dependency):
-        return dependency.name
+    def identify(self, requirement_or_candidate):
+        return requirement_or_candidate.name
 
     def get_preference(self, resolution, candidates, information):
         return len(candidates)

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -58,10 +58,11 @@ class PythonInputProvider(AbstractProvider):
             if _eval_marker(v.get("marker"))
         }
 
-    def identify(self, dependency):
-        name = packaging.utils.canonicalize_name(dependency.name)
-        if dependency.extras:
-            return "{}[{}]".format(name, ",".join(sorted(dependency.extras)))
+    def identify(self, requirement_or_candidate):
+        name = packaging.utils.canonicalize_name(requirement_or_candidate.name)
+        if requirement_or_candidate.extras:
+            extras_str = ",".join(sorted(requirement_or_candidate.extras))
+            return "{}[{}]".format(name, extras_str)
         return name
 
     def get_preference(self, resolution, candidates, information):

--- a/tests/functional/swift-package-manager/test_resolvers_swift.py
+++ b/tests/functional/swift-package-manager/test_resolvers_swift.py
@@ -78,8 +78,8 @@ class SwiftInputProvider(AbstractProvider):
         ]
         self.expectation = input_data["result"]
 
-    def identify(self, dependency):
-        return dependency.container["identifier"]
+    def identify(self, requirement_or_candidate):
+        return requirement_or_candidate.container["identifier"]
 
     def get_preference(self, resolution, candidates, information):
         return len(candidates)


### PR DESCRIPTION
This term has multiple conflicting definitions in this document.

In Candidate:

> Both of "requirement" and "dependency", however, SHOULD NOT be used when describing a Candidate, to avoid confusion.

In Requirement:

> A "dependency", if not clarified otherwise, also refers to this concept.

In this definition:

> A dependency can be either a requirement, or a candidate. In implementations you can treat it as the parent class and/or a protocol of the two.

---

I've opted to remove the single definition at the end, to give us nice and clean "dependency = requirement" naming. We'd likely need to change the variable name in `provider.identify(...)` to something better.

I propose just using `requirement_or_candidate` as the variable name, and avoiding this "pick a name" problem entirely. :P
