### PR TITLE
Reword the cautionary line about "specification" in Monillo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,8 +74,8 @@ people sometimes call this a "locked" or "pinned" dependency. Both of
 "requirement" and "dependency", however, SHOULD NOT be used when describing a
 Candidate, to avoid confusion.
 
-Some resolver architectures (e.g. Molinillo) refer this as a "specification",
-but this is not chosen to avoid confusion with a *Specifier*.
+Some resolver architectures refer this as a "specification", but it is not
+used here to avoid confusion with a *Specifier*.
 
 Requirement
 -----------

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -13,7 +13,7 @@ class AbstractProvider(object):
         raise NotImplementedError
 
     def get_preference(self, resolution, candidates, information):
-        """Produce a sort key for given specification based on preference.
+        """Produce a sort key for given requirement based on preference.
 
         The preference is defined as "I think this requirement should be
         resolved first". The lower the return value is, the more preferred
@@ -43,7 +43,7 @@ class AbstractProvider(object):
 
         A sortable value should be returned (this will be used as the `key`
         parameter of the built-in sorting function). The smaller the value is,
-        the more preferred this specification is (i.e. the sorting function
+        the more preferred this requirement is (i.e. the sorting function
         is called with `reverse=False`).
         """
         raise NotImplementedError


### PR DESCRIPTION
It seems to be an overtly specific reminder from back-when-we-were-looking-around-to-understand-what-to-do.