### PR TITLE
Pass ALL requirements to find_matches()

### DIFF
--- a/examples/extras_provider.py
+++ b/examples/extras_provider.py
@@ -22,8 +22,7 @@ from resolvelib.providers import AbstractProvider
 
 
 class ExtrasProvider(AbstractProvider):
-    """A provider that handles extras.
-    """
+    """A provider that handles extras."""
 
     def get_extras_for(self, requirement_or_candidate):
         """Given a requirement or candidate, return its extras.

--- a/examples/pypi_wheel_provider.py
+++ b/examples/pypi_wheel_provider.py
@@ -124,7 +124,8 @@ class PyPIProvider(ExtrasProvider):
     def get_preference(self, resolution, candidates, information):
         return len(candidates)
 
-    def find_matches(self, requirements):
+    def find_matches(self, identifier, all_requirements):
+        requirements = all_requirements[identifier]
         assert requirements, "resolver promises at least one requirement"
         assert not any(
             r.extras for r in requirements[1:]

--- a/examples/reporter_demo.py
+++ b/examples/reporter_demo.py
@@ -75,7 +75,8 @@ class Provider(resolvelib.AbstractProvider):
     def get_preference(self, resolution, candidates, information):
         return len(candidates)
 
-    def find_matches(self, requirement):
+    def find_matches(self, identifier, all_requirements):
+        requirement = all_requirements[identifier]
         deps = list(
             filter(
                 lambda candidate: self.is_satisfied_by(requirement, candidate),

--- a/examples/visualization/generate.py
+++ b/examples/visualization/generate.py
@@ -3,7 +3,8 @@ import os
 import jinja2
 
 environment = jinja2.Environment(
-    loader=jinja2.FileSystemLoader(os.path.dirname(__file__)), autoescape=True,
+    loader=jinja2.FileSystemLoader(os.path.dirname(__file__)),
+    autoescape=True,
 )
 
 

--- a/src/resolvelib/compat/collections_abc.py
+++ b/src/resolvelib/compat/collections_abc.py
@@ -1,6 +1,6 @@
-__all__ = ["Sequence"]
+__all__ = ["Mapping", "Sequence"]
 
 try:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 except ImportError:
-    from collections import Sequence
+    from collections import Mapping, Sequence

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -48,17 +48,20 @@ class AbstractProvider(object):
         """
         raise NotImplementedError
 
-    def find_matches(self, requirements):
-        """Find all possible candidates that satisfy the given requirements.
+    def find_matches(self, identifier, requirements):
+        """Find all possible candidates satisfying all identified requirements.
 
         This should try to get candidates based on the requirements' types.
         For VCS, local, and archive requirements, the one-and-only match is
         returned, and for a "named" requirement, the index(es) should be
         consulted to find concrete candidates for this requirement.
 
-        :param requirements: A collection of requirements which all of the
-            returned candidates must match. All requirements are guaranteed to
-            have the same identifier. The collection is never empty.
+        :param identifier: An identifier as returned by ``identify()``, that
+            candidates returned by this function should identify as.
+        :param requirements: A mapping of requirements the resolver knows.
+            Each key is a requirement identifiers. Each value is a non-empty
+            collection of requirements of that identifier. ``identifier`` is
+            guarenteed to exist in the mapping.
         :returns: An iterable that orders candidates by preference, e.g. the
             most preferred candidate should come first.
         """

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -1,6 +1,5 @@
 class AbstractProvider(object):
-    """Delegate class to provide requirement interface for the resolver.
-    """
+    """Delegate class to provide requirement interface for the resolver."""
 
     def identify(self, requirement_or_candidate):
         """Given a requirement or candidate, return an identifier for it.
@@ -88,8 +87,7 @@ class AbstractProvider(object):
 
 
 class AbstractResolver(object):
-    """The thing that performs the actual resolution work.
-    """
+    """The thing that performs the actual resolution work."""
 
     base_exception = Exception
 

--- a/src/resolvelib/reporters.py
+++ b/src/resolvelib/reporters.py
@@ -1,10 +1,8 @@
 class BaseReporter(object):
-    """Delegate class to provider progress reporting for the resolver.
-    """
+    """Delegate class to provider progress reporting for the resolver."""
 
     def starting(self):
-        """Called before the resolution actually starts.
-        """
+        """Called before the resolution actually starts."""
 
     def starting_round(self, index):
         """Called before each round of resolution starts.
@@ -20,8 +18,7 @@ class BaseReporter(object):
         """
 
     def ending(self, state):
-        """Called before the resolution ends successfully.
-        """
+        """Called before the resolution ends successfully."""
 
     def adding_requirement(self, requirement, parent):
         """Called when adding a new requirement into the resolve criteria.
@@ -34,9 +31,7 @@ class BaseReporter(object):
         """
 
     def backtracking(self, candidate):
-        """Called when rejecting a candidate during backtracking.
-        """
+        """Called when rejecting a candidate during backtracking."""
 
     def pinning(self, candidate):
-        """Called when adding a candidate to the potential solution.
-        """
+        """Called when adding a candidate to the potential solution."""

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -146,7 +146,8 @@ class Resolution(object):
             state = State(mapping=collections.OrderedDict(), criteria={})
         else:
             state = State(
-                mapping=base.mapping.copy(), criteria=base.criteria.copy(),
+                mapping=base.mapping.copy(),
+                criteria=base.criteria.copy(),
             )
         self._states.append(state)
 
@@ -178,7 +179,9 @@ class Resolution(object):
         except KeyError:
             pinned = None
         return self._p.get_preference(
-            pinned, criterion.candidates, criterion.information,
+            pinned,
+            criterion.candidates,
+            criterion.information,
         )
 
     def _is_current_pin_satisfying(self, name, criterion):
@@ -371,8 +374,7 @@ def _build_result(state):
 
 
 class Resolver(AbstractResolver):
-    """The thing that performs the actual resolution work.
-    """
+    """The thing that performs the actual resolution work."""
 
     base_exception = ResolverException
 

--- a/src/resolvelib/structs.py
+++ b/src/resolvelib/structs.py
@@ -4,8 +4,7 @@ from .compat import collections_abc
 
 
 class DirectedGraph(object):
-    """A graph structure with directed edges.
-    """
+    """A graph structure with directed edges."""
 
     def __init__(self):
         self._vertices = set()
@@ -22,8 +21,7 @@ class DirectedGraph(object):
         return key in self._vertices
 
     def copy(self):
-        """Return a shallow copy of this graph.
-        """
+        """Return a shallow copy of this graph."""
         other = DirectedGraph()
         other._vertices = set(self._vertices)
         other._forwards = {k: set(v) for k, v in self._forwards.items()}
@@ -31,8 +29,7 @@ class DirectedGraph(object):
         return other
 
     def add(self, key):
-        """Add a new vertex to the graph.
-        """
+        """Add a new vertex to the graph."""
         if key in self._vertices:
             raise ValueError("vertex exists")
         self._vertices.add(key)
@@ -40,8 +37,7 @@ class DirectedGraph(object):
         self._backwards[key] = set()
 
     def remove(self, key):
-        """Remove a vertex from the graph, disconnecting all edges from/to it.
-        """
+        """Remove vertex from graph, disconnecting all edges from/to it."""
         self._vertices.remove(key)
         for f in self._forwards.pop(key):
             self._backwards[f].remove(key)
@@ -96,7 +92,7 @@ class RequirementsView(collections_abc.Mapping):
     def __iter__(self):
         return itertools.chain(
             self._override,
-            (key for key in self._criteria if key not in self._override)
+            (key for key in self._criteria if key not in self._override),
         )
 
     def __len__(self):

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -85,7 +85,9 @@ class CocoaPodsInputProvider(AbstractProvider):
         case_data = _safe_json_load(filename)
 
         index_name = os.path.join(
-            INPUTS_DIR, "index", case_data.get("index", "awesome") + ".json",
+            INPUTS_DIR,
+            "index",
+            case_data.get("index", "awesome") + ".json",
         )
         self.index = _safe_json_load(index_name)
 

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -123,7 +123,8 @@ class CocoaPodsInputProvider(AbstractProvider):
             ]
             yield Candidate(entry["name"], version, dependencies)
 
-    def find_matches(self, requirements):
+    def find_matches(self, identifier, all_requirements):
+        requirements = all_requirements[identifier]
         name = requirements[0].name
         candidates = sorted(
             self._iter_matches(name, requirements),

--- a/tests/functional/python/py2index.py
+++ b/tests/functional/python/py2index.py
@@ -84,16 +84,24 @@ def parse_args(args: Optional[List[str]]) -> argparse.Namespace:
         default=".".join(str(v) for v in sys.version_info[:2]),
     )
     parser.add_argument(
-        "--interpreter", default=None,
+        "--interpreter",
+        default=None,
     )
     parser.add_argument(
-        "--platform", dest="platforms", action="append", default=None,
+        "--platform",
+        dest="platforms",
+        action="append",
+        default=None,
     )
     parser.add_argument(
-        "--output", type=_parse_output_path, required=True,
+        "--output",
+        type=_parse_output_path,
+        required=True,
     )
     parser.add_argument(
-        "--overwrite", action="store_true", default=False,
+        "--overwrite",
+        action="store_true",
+        default=False,
     )
     return parser.parse_args(args)
 

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -78,7 +78,8 @@ class PythonInputProvider(AbstractProvider):
                 name=name, version=version, extras=extras,
             )
 
-    def find_matches(self, requirements):
+    def find_matches(self, identifier, all_requirements):
+        requirements = all_requirements[identifier]
         name = packaging.utils.canonicalize_name(requirements[0].name)
         candidates = sorted(
             (c for c in self._iter_matches(name, requirements)),

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -75,7 +75,9 @@ class PythonInputProvider(AbstractProvider):
             if any(version not in r.specifier for r in requirements):
                 continue
             yield Candidate(
-                name=name, version=version, extras=extras,
+                name=name,
+                version=version,
+                extras=extras,
             )
 
     def find_matches(self, identifier, all_requirements):

--- a/tests/functional/swift-package-manager/test_resolvers_swift.py
+++ b/tests/functional/swift-package-manager/test_resolvers_swift.py
@@ -28,8 +28,7 @@ def _parse_version(s):
 
 
 def _is_version_allowed(version, ranges):
-    """Check version compatibility with Sematic Versioning.
-    """
+    """Check version compatibility with Sematic Versioning."""
     for r in ranges:
         r = _parse_version(r)
         if r[0] != version[0]:
@@ -44,8 +43,7 @@ def _is_version_allowed(version, ranges):
 
 
 def _calculate_preference(parsed_version):
-    """Calculate preference of a version with Minimal Version Selection.
-    """
+    """Calculate preference of a version with Minimal Version Selection."""
     if parsed_version[0] == 0:
         return (
             0,

--- a/tests/functional/swift-package-manager/test_resolvers_swift.py
+++ b/tests/functional/swift-package-manager/test_resolvers_swift.py
@@ -97,9 +97,9 @@ class SwiftInputProvider(AbstractProvider):
             preference = _calculate_preference(ver)
             yield (preference, Candidate(container, version))
 
-    def find_matches(self, requirements):
+    def find_matches(self, identifier, all_requirements):
         matches = sorted(
-            self._iter_matches(requirements),
+            self._iter_matches(all_requirements[identifier]),
             key=operator.itemgetter(0),
             reverse=True,
         )

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -23,7 +23,8 @@ def test_candidate_inconsistent_error():
         def get_dependencies(self, _):
             return []
 
-        def find_matches(self, rs):
+        def find_matches(self, identifier, all_requirements):
+            rs = all_requirements[identifier]
             assert len(rs) == 1 and rs[0] is requirement
             return [candidate]
 


### PR DESCRIPTION
For pypa/pip#8785. See https://github.com/pypa/pip/issues/8785#issuecomment-678885871 for context.

In order to know about `a @ ./a` when we run `find_matches` for `a[z]`, we need to somehow be able to access requirements from other packages. So this changes the arguments of `find_matches` again, and instead of passing a list of requirements, it now passes a mapping that contains all requirements. Thus we can do something like

```python
def find_matches(self, ident, all_reqs):
    reqs = all_reqs[ident]  # type: List[Requirement]
    for r in all_reqs.get(self.identify(reqs[0]), []):
        if r.is_explicit():
            return ExplicitCandidate(r)
    # Use index as we did...
```

This is posted so I can create a draft PR on pip to make sure things work.