### PR TITLE
Carry all incompatibilities during backtracking

### DIFF
--- a/src/resolvelib/structs.py
+++ b/src/resolvelib/structs.py
@@ -95,11 +95,11 @@ class _FactoryIterableView(object):
         """Provide an candidate iterable for `get_preference()`"""
         return self._factory()
 
-    def excluding(self, candidate):
-        """Create a new `Candidates` instance excluding `candidate`."""
+    def excluding(self, candidates):
+        """Create a new `Candidates` instance excluding `candidates`."""
 
         def factory():
-            return (c for c in self._factory() if c != candidate)
+            return (c for c in self._factory() if c not in candidates)
 
         return type(self)(factory)
 
@@ -129,9 +129,9 @@ class _SequenceIterableView(object):
         """Provide an candidate iterable for `get_preference()`"""
         return self._sequence
 
-    def excluding(self, candidate):
+    def excluding(self, candidates):
         """Create a new instance excluding `candidate`."""
-        return type(self)([c for c in self._sequence if c != candidate])
+        return type(self)([c for c in self._sequence if c not in candidates])
 
 
 def build_iter_view(matches):

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -72,6 +72,7 @@ def test_iter_view_for_preference_based_on_sequence(source):
 def test_itera_view_excluding(source):
     view = build_iter_view(source)
 
-    assert list(view.excluding(0)) == [1]
-    assert list(view.excluding(1)) == [0]
-    assert list(view.excluding(2)) == [0, 1]
+    assert list(view.excluding([0])) == [1]
+    assert list(view.excluding([2])) == [0, 1]
+    assert list(view.excluding([0, 1])) == []
+    assert list(view.excluding([1, 2])) == [0]


### PR DESCRIPTION
Consider this situation:

* Candidate `Ax` depends on `B`
* Candidate `B1` depends on `C==1` `D==1` `E==1`
* Candidate `B2` depends on `C==2` `D==1` `E==1`
* Candidate `C1` depends on `D==1`
* Candidate `C2` depends on `D==1`
* Candidate `D1` depends on `E!=1`

In the previous implementation, the conflict on `E` is discovered after we resolved `Ax-B1-C1-D1`. `D1` is marked as an incompatibility, we backtrack the `C1` pin. But now we don’t have an available `C`, and need to also backtrack the `B1` pin. At this point, however, the previous implementation would fail to “remember” that `D1` is also marked as incompatible, and proceed to try `B2`. That would eventually fail, we backtrack to the same point, and end up trying `B1` again. Now we are stuck.

This fix uses a list to remember all the candidates marked as incompatible along the whole backtrack process, and “re-mark” them in parent states. This makes the resolver aware, when it backtracks `B1`, that `B2` is also not viable, and avoid hitting it.