### PR TITLE
Redesign get_preference()

### DIFF
--- a/examples/pypi_wheel_provider.py
+++ b/examples/pypi_wheel_provider.py
@@ -122,8 +122,8 @@ class PyPIProvider(ExtrasProvider):
     def get_base_requirement(self, candidate):
         return Requirement("{}=={}".format(candidate.name, candidate.version))
 
-    def get_preference(self, resolution, candidates, information):
-        return len(candidates)
+    def get_preference(self, identifier, resolutions, candidates, information):
+        return sum(1 for _ in candidates[identifier])
 
     def find_matches(self, identifier, requirements, incompatibilities):
         requirements = list(requirements[identifier])

--- a/examples/reporter_demo.py
+++ b/examples/reporter_demo.py
@@ -72,8 +72,8 @@ class Provider(resolvelib.AbstractProvider):
     def identify(self, requirement_or_candidate):
         return requirement_or_candidate.name
 
-    def get_preference(self, resolution, candidates, information):
-        return len(candidates)
+    def get_preference(self, identifier, resolutions, candidates, information):
+        return sum(1 for _ in candidates[identifier])
 
     def find_matches(self, identifier, requirements, incompatibilities):
         name = identifier

--- a/news/74.feature.rst
+++ b/news/74.feature.rst
@@ -1,0 +1,5 @@
+Redesign ``get_preferences()`` to include resolution state on dependencies
+other than the currently working one, to allow the provider to better take
+account of the global resolver knowledge and determine the best strategy. The
+provider now can, for example, correctly calculate how far a dependency is
+from the root node in the graph.

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -9,28 +9,29 @@ class AbstractProvider(object):
         """
         raise NotImplementedError
 
-    def get_preference(self, resolution, candidates, information):
+    def get_preference(self, identifier, resolutions, candidates, information):
         """Produce a sort key for given requirement based on preference.
 
         The preference is defined as "I think this requirement should be
         resolved first". The lower the return value is, the more preferred
         this group of arguments is.
 
-        :param resolution: Currently pinned candidate, or `None`.
-        :param candidates: An iterable of possible candidates.
-        :param information: A list of requirement information.
+        :param identifier: An identifier as returned by ``identify()``. This
+            identifies the dependency matches of which should be returned.
+        :param resolutions: Mapping of candidates currently pinned by the
+            resolver. Each key is an identifier, and the value a candidate.
+            The candidate may conflict with requirements from ``information``.
+        :param candidates: Mapping of each dependency's possible candidates.
+            Each value is an iterator of candidates.
+        :param information: Mapping of requirement information of each package.
+            Each value is an iterator of *requirement information*.
 
-        The `candidates` iterable's exact type depends on the return type of
-        `find_matches()`. A sequence is passed-in as-is if possible. If it
-        returns a callble, the iterator returned by that callable is passed
-        in here.
+        A *requirement information* instance is a named tuple with two members:
 
-        Each element in `information` is a named tuple with two entries:
-
-        * `requirement` specifies a requirement contributing to the current
-          candidate list.
-        * `parent` specifies the candidate that provides (dependend on) the
-          requirement, or `None` to indicate a root requirement.
+        * ``requirement`` specifies a requirement contributing to the current
+          list of candidates.
+        * ``parent`` specifies the candidate that provides (dependend on) the
+          requirement, or ``None`` to indicate a root requirement.
 
         The preference could depend on a various of issues, including (not
         necessarily in this order):
@@ -43,10 +44,10 @@ class AbstractProvider(object):
         * Are there any known conflicts for this requirement? We should
           probably work on those with the most known conflicts.
 
-        A sortable value should be returned (this will be used as the `key`
+        A sortable value should be returned (this will be used as the ``key``
         parameter of the built-in sorting function). The smaller the value is,
         the more preferred this requirement is (i.e. the sorting function
-        is called with `reverse=False`).
+        is called with ``reverse=False``).
         """
         raise NotImplementedError
 
@@ -85,7 +86,7 @@ class AbstractProvider(object):
         The candidate is guarenteed to have been generated from the
         requirement.
 
-        A boolean should be returned to indicate whether `candidate` is a
+        A boolean should be returned to indicate whether ``candidate`` is a
         viable solution to the requirement.
         """
         raise NotImplementedError

--- a/src/resolvelib/providers.pyi
+++ b/src/resolvelib/providers.pyi
@@ -12,13 +12,7 @@ from typing import (
 
 from .reporters import BaseReporter
 from .resolvers import RequirementInformation
-from .structs import (
-    KT,
-    RT,
-    CT,
-    IterableView,
-    Matches,
-)
+from .structs import KT, RT, CT, Matches
 
 class Preference(Protocol):
     def __lt__(self, __other: Any) -> bool: ...
@@ -27,9 +21,10 @@ class AbstractProvider(Generic[RT, CT, KT]):
     def identify(self, requirement_or_candidate: Union[RT, CT]) -> KT: ...
     def get_preference(
         self,
-        resolution: Optional[CT],
-        candidates: IterableView[CT],
-        information: Collection[RequirementInformation[RT, CT]],
+        identifier: KT,
+        resolutions: Mapping[KT, CT],
+        candidates: Mapping[KT, Iterator[CT]],
+        information: Mapping[KT, Iterator[RequirementInformation[RT, CT]]],
     ) -> Preference: ...
     def find_matches(
         self,

--- a/src/resolvelib/structs.py
+++ b/src/resolvelib/structs.py
@@ -1,4 +1,5 @@
 import itertools
+
 from .compat import collections_abc
 
 
@@ -120,18 +121,6 @@ class _FactoryIterableView(object):
     def __iter__(self):
         return self._factory()
 
-    def for_preference(self):
-        """Provide an candidate iterable for `get_preference()`"""
-        return self._factory()
-
-    def excluding(self, candidates):
-        """Create a new instance excluding specified candidates."""
-
-        def factory():
-            return (c for c in self._factory() if c not in candidates)
-
-        return type(self)(factory)
-
 
 class _SequenceIterableView(object):
     """Wrap an iterable returned by find_matches().
@@ -153,17 +142,6 @@ class _SequenceIterableView(object):
 
     def __iter__(self):
         return iter(self._sequence)
-
-    def __len__(self):
-        return len(self._sequence)
-
-    def for_preference(self):
-        """Provide an candidate iterable for `get_preference()`"""
-        return self._sequence
-
-    def excluding(self, candidates):
-        """Create a new instance excluding specified candidates."""
-        return type(self)([c for c in self._sequence if c not in candidates])
 
 
 def build_iter_view(matches):

--- a/src/resolvelib/structs.pyi
+++ b/src/resolvelib/structs.pyi
@@ -17,7 +17,7 @@ _T = TypeVar("_T")
 Matches = Union[Iterable[CT], Callable[[], Iterator[CT]]]
 
 class IterableView(Container[CT], Iterable[CT], metaclass=ABCMeta):
-    def excluding(self: _T, candidates: Container[CT]) -> _T: ...
+    pass
 
 class DirectedGraph(Generic[KT]):
     def __iter__(self) -> Iterator[KT]: ...

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -105,8 +105,8 @@ class CocoaPodsInputProvider(AbstractProvider):
     def identify(self, requirement_or_candidate):
         return requirement_or_candidate.name
 
-    def get_preference(self, resolution, candidates, information):
-        return len(candidates)
+    def get_preference(self, identifier, resolutions, candidates, information):
+        return sum(1 for _ in candidates[identifier])
 
     def _iter_matches(self, name, requirements, incompatibilities):
         try:

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -72,10 +72,9 @@ class PythonInputProvider(AbstractProvider):
             return "{}[{}]".format(name, extras_str)
         return name
 
-    def get_preference(self, resolution, candidates, information):
-        transitive = all(parent is not None for _, parent in information)
-        key = next(iter(candidates)).name if candidates else ""
-        return (transitive, key)
+    def get_preference(self, identifier, resolutions, candidates, information):
+        transitive = all(p is not None for _, p in information[identifier])
+        return (transitive, identifier)
 
     def _iter_matches(self, identifier, requirements, incompatibilities):
         name, _, _ = identifier.partition("[")

--- a/tests/functional/swift-package-manager/test_resolvers_swift.py
+++ b/tests/functional/swift-package-manager/test_resolvers_swift.py
@@ -79,8 +79,8 @@ class SwiftInputProvider(AbstractProvider):
     def identify(self, requirement_or_candidate):
         return requirement_or_candidate.container["identifier"]
 
-    def get_preference(self, resolution, candidates, information):
-        return len(candidates)
+    def get_preference(self, identifier, resolutions, candidates, information):
+        return sum(1 for _ in candidates[identifier])
 
     def _iter_matches(self, identifier, requirements, incompatibilities):
         bad_versions = {c.version for c in incompatibilities[identifier]}

--- a/tests/test_structs.py
+++ b/tests/test_structs.py
@@ -50,39 +50,3 @@ def test_iter_view_multiple_iterable(source):
     next(iterator_a)
     assert next(iterator_b) == 0
     assert next(iterator_a) == 1
-
-
-@pytest.mark.parametrize("source", [_generate])
-def test_iter_view_for_preference_based_on_factory(source):
-    """Factory-based view returns an iterator for preference."""
-    view = build_iter_view(source)
-    iterator = view.for_preference()
-    assert iter(iterator) is iterator, "not an iterator"
-    assert list(iterator) == [0, 1]
-
-
-@pytest.mark.parametrize("source", [[0, 1], iter([0, 1])])
-def test_iter_view_for_preference_based_on_sequence(source):
-    """Sequence-based view returns a sequence for preference."""
-    view = build_iter_view(source)
-    assert view.for_preference() == [0, 1]
-
-
-@pytest.mark.parametrize(
-    "source",
-    [lambda: _generate, lambda: [0, 1], _generate],
-    ids=["callable", "sequence", "iterator"],
-)
-@pytest.mark.parametrize(
-    "exclusion, expected",
-    [
-        ([1], [0]),
-        ([0, 1], []),
-        ([1, 2], [0]),
-        ([2, 3], [0, 1]),
-    ],
-    ids=["one", "all", "partial", "none"],
-)
-def test_itera_view_excluding(source, exclusion, expected):
-    view = build_iter_view(source())
-    assert list(view.excluding(exclusion)) == expected


### PR DESCRIPTION
My plan is to

* [x] Wait on pypa/pip#9699 (which is currently blocked by another PR).
* [x] Create a 0.6.0 with the current master (i.e. without this).
* [x] Try integrating 0.6.0 into pip, fixing possible problems along the way.
* [x] Rebase this against master. Create a news fragment for #74.
* Merge this into master and close #74.
* Create 0.7.0 from master.
* Try integrating 0.7.0 into pip.
* Done?