### PR TITLE
Store failure cause and provide to _get_preference

### DIFF
--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -234,6 +234,7 @@ class Resolution(object):
             # backtracking looks at this mapping to get the last pin.
             self.state.mapping.pop(name, None)
             self.state.mapping[name] = candidate
+
             return []
 
         # All candidates tried, nothing works. This criterion is a dead

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -234,7 +234,6 @@ class Resolution(object):
             # backtracking looks at this mapping to get the last pin.
             self.state.mapping.pop(name, None)
             self.state.mapping[name] = candidate
-    
             return []
 
         # All candidates tried, nothing works. This criterion is a dead

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -186,7 +186,7 @@ class Resolution(object):
                 self.state.criteria,
                 operator.attrgetter("information"),
             ),
-            backtrack_causes=self.state.backtrack_causes
+            backtrack_causes=self.state.backtrack_causes,
         )
 
     def _is_current_pin_satisfying(self, name, criterion):
@@ -338,10 +338,12 @@ class Resolution(object):
 
         # Initialize the root state.
         self._states = [
-            State(mapping=collections.OrderedDict(),
-                  criteria={},
-                  backtrack_causes=[])
-            ]
+            State(
+                mapping=collections.OrderedDict(),
+                criteria={},
+                backtrack_causes=[],
+            )
+        ]
         for r in requirements:
             try:
                 self._add_to_criteria(self.state.criteria, r, parent=None)
@@ -376,8 +378,8 @@ class Resolution(object):
                 # an unpinned state, so we can work on it in the next round.
                 success = self._backtrack()
                 self.state.backtrack_causes[:] = [
-                        i for c in failure_causes for i in c.information
-                    ]
+                    i for c in failure_causes for i in c.information
+                ]
 
                 # Dead ends everywhere. Give up.
                 if not success:

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -375,7 +375,6 @@ class Resolution(object):
 
                 # Dead ends everywhere. Give up.
                 if not success:
-                    causes = [i for c in failure_causes for i in c.information]
                     raise ResolutionImpossible(self._failure_causes)
             else:
                 # Pinning was successful. Push a new state to do another pin.

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -131,7 +131,7 @@ class Resolution(object):
         state = State(
             mapping=base.mapping.copy(),
             criteria=base.criteria.copy(),
-            backtrack_causes=base.backtrack_causes.copy(),
+            backtrack_causes=base.backtrack_causes[:],
         )
         self._states.append(state)
 

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -113,6 +113,7 @@ class Resolution(object):
         self._p = provider
         self._r = reporter
         self._states = []
+        self._failure_casues = []
 
     @property
     def state(self):
@@ -185,6 +186,7 @@ class Resolution(object):
                 self.state.criteria,
                 operator.attrgetter("information"),
             ),
+            failure_causes=self._failure_causes
         )
 
     def _is_current_pin_satisfying(self, name, criterion):
@@ -369,11 +371,12 @@ class Resolution(object):
                 # Backtrack if pinning fails. The backtrack process puts us in
                 # an unpinned state, so we can work on it in the next round.
                 success = self._backtrack()
+                self._failure_causes = [i for c in failure_causes for i in c.information]
 
                 # Dead ends everywhere. Give up.
                 if not success:
                     causes = [i for c in failure_causes for i in c.information]
-                    raise ResolutionImpossible(causes)
+                    raise ResolutionImpossible(self._failure_causes)
             else:
                 # Pinning was successful. Push a new state to do another pin.
                 self._push_new_state()

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -113,7 +113,7 @@ class Resolution(object):
         self._p = provider
         self._r = reporter
         self._states = []
-        self._failure_casues = []
+        self._failure_causes = []
 
     @property
     def state(self):

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -99,7 +99,7 @@ class ResolutionTooDeep(ResolutionError):
 
 
 # Resolution state in a round.
-State = collections.namedtuple("State", "mapping criteria")
+State = collections.namedtuple("State", "mapping criteria backtrack_causes")
 
 
 class Resolution(object):
@@ -113,7 +113,6 @@ class Resolution(object):
         self._p = provider
         self._r = reporter
         self._states = []
-        self._failure_causes = []
 
     @property
     def state(self):
@@ -132,6 +131,7 @@ class Resolution(object):
         state = State(
             mapping=base.mapping.copy(),
             criteria=base.criteria.copy(),
+            backtrack_causes=base.backtrack_causes.copy(),
         )
         self._states.append(state)
 
@@ -186,7 +186,7 @@ class Resolution(object):
                 self.state.criteria,
                 operator.attrgetter("information"),
             ),
-            failure_causes=self._failure_causes
+            backtrack_causes=self.state.backtrack_causes
         )
 
     def _is_current_pin_satisfying(self, name, criterion):
@@ -234,7 +234,7 @@ class Resolution(object):
             # backtracking looks at this mapping to get the last pin.
             self.state.mapping.pop(name, None)
             self.state.mapping[name] = candidate
-
+    
             return []
 
         # All candidates tried, nothing works. This criterion is a dead
@@ -337,7 +337,11 @@ class Resolution(object):
         self._r.starting()
 
         # Initialize the root state.
-        self._states = [State(mapping=collections.OrderedDict(), criteria={})]
+        self._states = [
+            State(mapping=collections.OrderedDict(),
+                  criteria={},
+                  backtrack_causes=[])
+            ]
         for r in requirements:
             try:
                 self._add_to_criteria(self.state.criteria, r, parent=None)
@@ -371,11 +375,13 @@ class Resolution(object):
                 # Backtrack if pinning fails. The backtrack process puts us in
                 # an unpinned state, so we can work on it in the next round.
                 success = self._backtrack()
-                self._failure_causes = [i for c in failure_causes for i in c.information]
+                self.state.backtrack_causes[:] = [
+                        i for c in failure_causes for i in c.information
+                    ]
 
                 # Dead ends everywhere. Give up.
                 if not success:
-                    raise ResolutionImpossible(self._failure_causes)
+                    raise ResolutionImpossible(self.state.backtrack_causes)
             else:
                 # Pinning was successful. Push a new state to do another pin.
                 self._push_new_state()

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -105,7 +105,14 @@ class CocoaPodsInputProvider(AbstractProvider):
     def identify(self, requirement_or_candidate):
         return requirement_or_candidate.name
 
-    def get_preference(self, identifier, resolutions, candidates, information):
+    def get_preference(
+        self,
+        identifier,
+        resolutions,
+        candidates,
+        information,
+        backtrack_causes,
+    ):
         return sum(1 for _ in candidates[identifier])
 
     def _iter_matches(self, name, requirements, incompatibilities):

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -72,7 +72,14 @@ class PythonInputProvider(AbstractProvider):
             return "{}[{}]".format(name, extras_str)
         return name
 
-    def get_preference(self, identifier, resolutions, candidates, information):
+    def get_preference(
+        self,
+        identifier,
+        resolutions,
+        candidates,
+        information,
+        backtrack_causes,
+    ):
         transitive = all(p is not None for _, p in information[identifier])
         return (transitive, identifier)
 

--- a/tests/functional/swift-package-manager/test_resolvers_swift.py
+++ b/tests/functional/swift-package-manager/test_resolvers_swift.py
@@ -79,7 +79,14 @@ class SwiftInputProvider(AbstractProvider):
     def identify(self, requirement_or_candidate):
         return requirement_or_candidate.container["identifier"]
 
-    def get_preference(self, identifier, resolutions, candidates, information):
+    def get_preference(
+        self,
+        identifier,
+        resolutions,
+        candidates,
+        information,
+        backtrack_causes,
+    ):
         return sum(1 for _ in candidates[identifier])
 
     def _iter_matches(self, identifier, requirements, incompatibilities):


### PR DESCRIPTION
As per https://github.com/pypa/pip/issues/10479

If pip prefers failure causes then resolvelib must provide them to get_preference

Required for https://github.com/pypa/pip/pull/10481