### PR TITLE
Implement dedicated causes object

### DIFF
--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -86,6 +86,9 @@ class Causes(object):
     def __eq__(self, other):
         return self.causes == other.causes
 
+    def __bool__(self):
+        return bool(self.causes)
+
 
 class Criterion(object):
     """Representation of possible resolution results of a package.

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -88,6 +88,9 @@ class Causes(object):
     def __bool__(self):
         return bool(self.causes)
 
+    def __nonzero__(self):
+        return bool(self.causes)
+
 
 class Criterion(object):
     """Representation of possible resolution results of a package.

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -77,7 +77,7 @@ class Causes(object):
         return self._information
 
     def _causes_to_names(self):
-        for c in self.causes:
+        for c in self.information:
             yield c.requirement.name
             if c.parent:
                 yield c.parent.name

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -71,9 +71,7 @@ class Causes(object):
         if self._information is not None:
             return self._information
 
-        self._information = [
-            i for c in self.causes for i in c.information
-        ]
+        self._information = [i for c in self.causes for i in c.information]
         return self._information
 
     def _causes_to_names(self):

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -44,12 +44,17 @@ class InconsistentCandidate(ResolverException):
 
 class Causes(object):
     def __init__(self, causes):
-        self.causes = causes
+        self._causes = causes
         self._names = None
         self._causes_information = None
 
+    @property
+    def causes(self):
+        return self._causes
+
+    @causes.setter
     def update_causes(self, causes):
-        self.causes = causes.causes
+        self._causes = causes
         self._names = None
         self._causes_information = None
 
@@ -424,7 +429,7 @@ class Resolution(object):
                 # an unpinned state, so we can work on it in the next round.
                 self._r.resolving_conflicts(causes=causes)
                 success = self._backtrack()
-                self.state.backtrack_causes.update_causes(causes)
+                self.state.backtrack_causes.causes = causes.causes
 
                 # Dead ends everywhere. Give up.
                 if not success:

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -52,7 +52,6 @@ class Causes(object):
     def causes(self):
         return self._causes
 
-    @causes.setter
     def update_causes(self, causes):
         self._causes = causes
         self._names = None
@@ -432,7 +431,9 @@ class Resolution(object):
                     raise ResolutionImpossible(failure_causes.information)
 
                 # Attach causes to backtrack causes in state
-                self.state.backtrack_causes.causes = failure_causes.causes
+                self.state.backtrack_causes.update_causes(
+                    failure_causes.causes
+                )
             else:
                 # Pinning was successful. Push a new state to do another pin.
                 self._push_new_state()

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -282,11 +282,11 @@ class Resolution(object):
             self.state.mapping.pop(name, None)
             self.state.mapping[name] = candidate
 
-            return []
+            return Causes([])
 
         # All candidates tried, nothing works. This criterion is a dead
         # end, signal for backtracking.
-        return causes
+        return Causes(causes)
 
     def _backtrack(self):
         """Perform backtracking.
@@ -421,18 +421,17 @@ class Resolution(object):
             failure_causes = self._attempt_to_pin_criterion(name)
 
             if failure_causes:
-                causes = Causes(failure_causes)
                 # Backtrack if pinning fails. The backtrack process puts us in
                 # an unpinned state, so we can work on it in the next round.
-                self._r.resolving_conflicts(causes=causes.information)
+                self._r.resolving_conflicts(causes=failure_causes.information)
                 success = self._backtrack()
 
                 # Dead ends everywhere. Give up.
                 if not success:
-                    raise ResolutionImpossible(causes.information)
+                    raise ResolutionImpossible(failure_causes.information)
 
                 # Attach causes to backtrack causes in state
-                self.state.backtrack_causes.causes = causes.causes
+                self.state.backtrack_causes.causes = failure_causes.causes
             else:
                 # Pinning was successful. Push a new state to do another pin.
                 self._push_new_state()

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -280,11 +280,11 @@ class Resolution(object):
             self.state.mapping.pop(name, None)
             self.state.mapping[name] = candidate
 
-            return Causes([])
+            return Causes(causes=[])
 
         # All candidates tried, nothing works. This criterion is a dead
         # end, signal for backtracking.
-        return Causes(causes)
+        return Causes(causes=causes)
 
     def _backtrack(self):
         """Perform backtracking.
@@ -386,7 +386,7 @@ class Resolution(object):
             State(
                 mapping=collections.OrderedDict(),
                 criteria={},
-                backtrack_causes=Causes([]),
+                backtrack_causes=Causes(causes=[]),
             )
         ]
         for r in requirements:


### PR DESCRIPTION
This is proof of concept to address issues raised in https://github.com/sarugaku/resolvelib/pull/92#issuecomment-955139430 

Derived information can then be calculated and cached as needed.  In particular the downstream provider can run `identifier in backtrack_causes.names` where `names` is a property that calculates the underlying information lazily and only has to be re-calculated if the underlying `causes` are changed.

I'm trying to see if this approach would have consensuses, several things in the code would need fixing before merging.