### PR TITLE
Fix mypy failures

### DIFF
--- a/src/resolvelib/compat/collections_abc.py
+++ b/src/resolvelib/compat/collections_abc.py
@@ -3,4 +3,4 @@ __all__ = ["Mapping", "Sequence"]
 try:
     from collections.abc import Mapping, Sequence
 except ImportError:
-    from collections import Mapping, Sequence
+    from collections import Mapping, Sequence  # type: ignore


### PR DESCRIPTION
Related to https://github.com/python/mypy/issues/1153

This became an issue with mypy running on Python 3.10 (I guess `collections.Mapping` and `collections.Sequence` were finally removed).

It's causing mypy to fail in latest PRs: https://github.com/sarugaku/resolvelib/pull/93