### PR TITLE
Let downstream library to define causes object

### DIFF
--- a/examples/extras_provider.py
+++ b/examples/extras_provider.py
@@ -52,3 +52,6 @@ class ExtrasProvider(AbstractProvider):
             req = self.get_base_requirement(candidate)
             deps.append(req)
         return deps
+
+    def causes(self, causes):
+        return [i for c in causes for i in c.information]

--- a/src/resolvelib/providers.pyi
+++ b/src/resolvelib/providers.pyi
@@ -1,14 +1,4 @@
-from typing import (
-    Any,
-    Collection,
-    Generic,
-    Iterable,
-    Iterator,
-    Mapping,
-    Optional,
-    Protocol,
-    Union,
-)
+from typing import Any, Generic, Iterable, Iterator, Mapping, Protocol, Union
 
 from .reporters import BaseReporter
 from .resolvers import RequirementInformation
@@ -25,6 +15,7 @@ class AbstractProvider(Generic[RT, CT, KT]):
         resolutions: Mapping[KT, CT],
         candidates: Mapping[KT, Iterator[CT]],
         information: Mapping[KT, Iterator[RequirementInformation[RT, CT]]],
+        backtrack_causes: Any
     ) -> Preference: ...
     def find_matches(
         self,
@@ -34,6 +25,7 @@ class AbstractProvider(Generic[RT, CT, KT]):
     ) -> Matches: ...
     def is_satisfied_by(self, requirement: RT, candidate: CT) -> bool: ...
     def get_dependencies(self, candidate: CT) -> Iterable[RT]: ...
+    def causes(self, causes: Any) -> Any: ...
 
 class AbstractResolver(Generic[RT, CT, KT]):
     base_exception = Exception

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -341,7 +341,7 @@ class Resolution(object):
             State(
                 mapping=collections.OrderedDict(),
                 criteria={},
-                backtrack_causes=self._p.causes([]),
+                backtrack_causes=self._p.causes(causes=[]),
             )
         ]
         for r in requirements:

--- a/src/resolvelib/resolvers.pyi
+++ b/src/resolvelib/resolvers.pyi
@@ -1,4 +1,5 @@
 from typing import (
+    Any,
     Collection,
     Generic,
     Iterable,
@@ -50,7 +51,7 @@ class InconsistentCandidate(ResolverException, Generic[RT, CT, KT]):
     criterion: Criterion[RT, CT, KT]
 
 class ResolutionImpossible(ResolutionError, Generic[RT, CT]):
-    causes: List[RequirementInformation[RT, CT]]
+    causes: Any
 
 class ResolutionTooDeep(ResolutionError):
     round_count: int

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -153,6 +153,9 @@ class CocoaPodsInputProvider(AbstractProvider):
     def get_dependencies(self, candidate):
         return candidate.deps
 
+    def causes(self, causes):
+        return [i for c in causes for i in c.information]
+
 
 XFAIL_CASES = {
     # ResolveLib does not complain about cycles, so these will be different.

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -119,6 +119,9 @@ class PythonInputProvider(AbstractProvider):
     def get_dependencies(self, candidate):
         return list(self._iter_dependencies(candidate))
 
+    def causes(self, causes):
+        return [i for c in causes for i in c.information]
+
 
 INPUTS_DIR = os.path.abspath(os.path.join(__file__, "..", "inputs"))
 

--- a/tests/functional/swift-package-manager/test_resolvers_swift.py
+++ b/tests/functional/swift-package-manager/test_resolvers_swift.py
@@ -132,6 +132,9 @@ class SwiftInputProvider(AbstractProvider):
     def get_dependencies(self, candidate):
         return list(self._iter_dependencies(candidate))
 
+    def causes(self, causes):
+        return [i for c in causes for i in c.information]
+
 
 @pytest.fixture(
     params=[os.path.join(INPUTS_DIR, n) for n in INPUT_NAMES],

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -38,6 +38,9 @@ def test_candidate_inconsistent_error():
             assert candidate is self.candidate
             return False
 
+        def causes(self, causes):
+            return [i for c in causes for i in c.information]
+
     resolver = Resolver(Provider(requirement, candidate), BaseReporter())
 
     with pytest.raises(InconsistentCandidate) as ctx:
@@ -83,6 +86,9 @@ def test_candidate_depends_on_requirements_of_same_identifier(specifiers):
 
         def is_satisfied_by(self, requirement, candidate):
             return candidate[1] in requirement[1]
+
+        def causes(self, causes):
+            return [i for c in causes for i in c.information]
 
     # Now when resolved, both requirements to child specified by parent should
     # be pulled, and the resolver should choose v1, not v2 (happens if the
@@ -130,6 +136,9 @@ def test_resolving_conflicts():
 
         def is_satisfied_by(self, requirement, candidate):
             return candidate[1] in requirement[1]
+
+        def causes(self, causes):
+            return [i for c in causes for i in c.information]
 
     def run_resolver(*args):
         reporter = Reporter()


### PR DESCRIPTION
Addresses comments made in https://github.com/sarugaku/resolvelib/pull/93#issuecomment-970470701

Provider now has a `causes` method that allows it to define what the causes object looks like.

The returned object must implement the following:
 * Have truthiness
 * Be copyiable using `copy.copy`

For example if would be possible to implement the method like so to preserve the existing behavior (would work on Python 2.7 to 3.10):

```
def causes(self, causes):
    return [i for c in causes for i in c.information]
```

There is an accompanying pip PR (https://github.com/pypa/pip/pull/10732) that leverages this new interface to resolve the performance issues described in https://github.com/pypa/pip/pull/10621

Need some hints / help defining a better type than "Any" for "causes" if that matters.