### PR TITLE
resolvelib/providers.pyi: add hint for `backtrack_causes`

### DIFF
--- a/src/resolvelib/providers.pyi
+++ b/src/resolvelib/providers.pyi
@@ -1,12 +1,11 @@
 from typing import (
     Any,
-    Collection,
     Generic,
     Iterable,
     Iterator,
     Mapping,
-    Optional,
     Protocol,
+    Sequence,
     Union,
 )
 
@@ -25,6 +24,7 @@ class AbstractProvider(Generic[RT, CT, KT]):
         resolutions: Mapping[KT, CT],
         candidates: Mapping[KT, Iterator[CT]],
         information: Mapping[KT, Iterator[RequirementInformation[RT, CT]]],
+        backtrack_causes: Sequence[RequirementInformation[RT, CT]],
     ) -> Preference: ...
     def find_matches(
         self,


### PR DESCRIPTION
This is based on my reading of the docs:

```
        :param backtrack_causes: Sequence of requirement information that were
            the requirements that caused the resolver to most recently backtrack.
```

Closes #104.

Signed-off-by: William Woodruff <william@trailofbits.com>