### PR TITLE
Lazy sequence iterview

### DIFF
--- a/src/resolvelib/structs.py
+++ b/src/resolvelib/structs.py
@@ -116,7 +116,8 @@ class _FactoryIterableView(object):
     """
 
     def __init__(self, factory):
-        self._iterable = factory()
+        self._factory = factory
+        self._iterable = None
 
     def __repr__(self):
         return "{}({})".format(type(self).__name__, list(self))
@@ -131,7 +132,10 @@ class _FactoryIterableView(object):
     __nonzero__ = __bool__  # XXX: Python 2.
 
     def __iter__(self):
-        self._iterable, current = itertools.tee(self._iterable)
+        iterable = (
+            self._factory() if self._iterable is None else self._iterable
+        )
+        self._iterable, current = itertools.tee(iterable)
         return current
 
 

--- a/src/resolvelib/structs.py
+++ b/src/resolvelib/structs.py
@@ -153,13 +153,12 @@ class _SequenceIterableView(object):
     __nonzero__ = __bool__  # XXX: Python 2.
 
     def __iter__(self):
-        return iter(self._sequence)
+        self._sequence, current = itertools.tee(self._sequence)
+        return current
 
 
 def build_iter_view(matches):
     """Build an iterable view from the value returned by `find_matches()`."""
     if callable(matches):
         return _FactoryIterableView(matches)
-    if not isinstance(matches, collections_abc.Sequence):
-        matches = list(matches)
     return _SequenceIterableView(matches)

--- a/src/resolvelib/structs.pyi
+++ b/src/resolvelib/structs.pyi
@@ -16,7 +16,7 @@ RT = TypeVar("RT")  # Requirement.
 CT = TypeVar("CT")  # Candidate.
 _T = TypeVar("_T")
 
-Matches = Union[Iterable[CT], Callable[[], Iterator[CT]]]
+Matches = Union[Iterable[CT], Callable[[], Iterable[CT]]]
 
 class IteratorMapping(Mapping[KT, _T], metaclass=ABCMeta):
     pass


### PR DESCRIPTION
Result iterable returned by `find_matches()` won't be consumed all at once.
Also unite the `_FactoryIterableView` with `_SequenceIterableView`
With the change, the underlying iterable is guaranteed to be consumed only once.