### PR TITLE
fixed invalid version specifiers in a test index

### DIFF
--- a/tests/functional/python/inputs/index/same-package.json
+++ b/tests/functional/python/inputs/index/same-package.json
@@ -2,37 +2,37 @@
 	"package-a": {
 		"0.1.0": {
 			"dependencies": [
-				"package-x=='0.1.0'; extra == 'x'",
-				"package-y=='0.1.0'; extra == 'y'",
-				"package-z=='0.1.0'; extra == 'z'"
+				"package-x==0.1.0; extra == 'x'",
+				"package-y==0.1.0; extra == 'y'",
+				"package-z==0.1.0; extra == 'z'"
 			]
 		},
 		"1.0.0": {
 			"dependencies": [
-				"package-x=='1.0.0'; extra == 'x'",
-				"package-y=='1.0.0'; extra == 'y'",
-				"package-z=='1.0.0'; extra == 'z'"
+				"package-x==1.0.0; extra == 'x'",
+				"package-y==1.0.0; extra == 'y'",
+				"package-z==1.0.0; extra == 'z'"
 			]
 		},
 		"1.1.0": {
 			"dependencies": [
-				"package-x=='1.1.0'; extra == 'x'",
-				"package-y=='1.1.0'; extra == 'y'",
-				"package-z=='1.1.0'; extra == 'z'"
+				"package-x==1.1.0; extra == 'x'",
+				"package-y==1.1.0; extra == 'y'",
+				"package-z==1.1.0; extra == 'z'"
 			]
 		},
 		"1.2.0": {
 			"dependencies": [
-				"package-x=='1.2.0'; extra == 'x'",
-				"package-y=='1.2.0'; extra == 'y'",
-				"package-z=='1.2.0'; extra == 'z'"
+				"package-x==1.2.0; extra == 'x'",
+				"package-y==1.2.0; extra == 'y'",
+				"package-z==1.2.0; extra == 'z'"
 			]
 		},
 		"1.3.0": {
 			"dependencies": [
-				"package-x=='1.3.0'; extra == 'x'",
-				"package-y=='1.3.0'; extra == 'y'",
-				"package-z=='1.3.0'; extra == 'z'"
+				"package-x==1.3.0; extra == 'x'",
+				"package-y==1.3.0; extra == 'y'",
+				"package-z==1.3.0; extra == 'z'"
 			]
 		}
 	},

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -129,7 +129,6 @@ CASE_NAMES = [name for name in os.listdir(CASE_DIR) if name.endswith(".json")]
 
 XFAIL_CASES = {
     "pyrex-1.9.8.json": "Too many rounds (>500)",
-    "same-package-extras.json": "State not cleaned up correctly",
 }
 
 


### PR DESCRIPTION
I believe this resolves part of #103. It removes all `LegacyVersion` deprecation warnings for the Python tests. The others are more tricky because they aren't versions for Python packages, therefore they aren't PEP440 compliant. I did not address those for now.

If accepted (within the month of October, which may be a bit of a stretch at this point), might I ask once more to add the [hacktoberfest-accepted](https://hacktoberfest.com/participation/) label to the pull request?