### PR TITLE
Implement backjumping over unrelated states

### DIFF
--- a/news/113.feature.rst
+++ b/news/113.feature.rst
@@ -1,0 +1,1 @@
+Implement backjumping to significantly speed up the resolution process by skipping over irrelevant parts of the resolution search space.


### PR DESCRIPTION
The current backtracking logic assumes that the last state in the stack
is the state that caused the incompatibility. This is not always the case.
For example, given three requirements A, B and C, with dependencies
A1, B1 and C1, where A1 and B1 are incompatible.
The requirements are processed one after the other, so the last state
is related to C, while the incompatibility is caused by B.

The current behavior causes significant slowdowns in case there are
many candidates for B and C, as all their combination are evaluated
before a compatible version of B can be found.

The new behavior discards a state if the packages that cause the
incompatibility are not found among the direct dependencies
of the candidate in the current state.
In our example, this causes the state related to C to be dropped
without evaluating any of its candidates, until a compatible candidate
of B is found.

This change can be tested with the following requirements:
```
boto3==1.10.16
s3fs
seaborn
```