### PR TITLE
CI: fix the CI failures on packaging > 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - run: nox -s release -- --version '' --repo '' --prebump ''
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [lint]
     strategy:
       fail-fast: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
       fail-fast: true
       matrix:
         python:
-          - "2.7"
           - "3.10"
           - "3.9"
           - "3.8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,18 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install .[lint,test]
-      - run: black --check .
-      - run: isort .
-      - run: flake8 .
-      - run: mypy src/ tests/
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - run: pip install nox
+      - run: nox -s lint
   package:
     name: Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - run: pip install .[release]
-      - run: python -m build .
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - run: pip install nox
+      - run: nox -s release -- --version '' --repo '' --prebump ''
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -39,9 +36,9 @@ jobs:
           - "3.7"
           - "3.6"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - run: pip install .[test]
-      - run: pytest tests
+      - run: pip install nox
+      - run: nox -s tests-${{ matrix.python }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ def lint(session):
     session.run("mypy", "src", "tests")
 
 
-@nox.session(python=["3.9", "3.8", "3.7", "3.6", "3.5", "2.7"])
+@nox.session(python=["3.10", "3.9", "3.8", "3.7", "3.6", "2.7"])
 def tests(session):
     session.install(".[test]")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ lint =
 	types-requests
 test =
 	commentjson
-	packaging<22.0  # to handle non-python standard versions
+	packaging
 	pytest
 release =
 	build

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ universal = 1
 [flake8]
 max-line-length = 88
 select = C,E,F,W,B
-ignore = E203, W503
+ignore = E203, W503, F401
 exclude =
 	.git,
 	.venv,

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ lint =
 	types-requests
 test =
 	commentjson
-	packaging
+	packaging<22.0  # to handle non-python standard versions
 	pytest
 release =
 	build

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -171,7 +171,7 @@ def test_pin_conflict_with_self(monkeypatch, reporter):
     Verify correct behavior of attempting to pin a candidate version that conflicts
     with a previously pinned (now invalidated) version for that same candidate (#91).
     """
-    Candidate = Tuple[
+    Candidate = Tuple[  # noqa: F841
         str, Version, Sequence[str]
     ]  # name, version, requirements
     all_candidates = {


### PR DESCRIPTION
Because there are test cases against indexes for other languages and their version don't follow the python standards, ~~we have to set version cap of packaging to `<22.0` for testing.~~

Also, switch to `nox` in CI workflows.

* * *
Fixes #114