### PR TITLE
Declare supported Python versions in dist meta

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ package_dir =
 packages = find:
 include_package_data = true
 zip_safe = false
-python_requires = >=2.7, !=3.0, !=3.1, !=3.2, !=3.3, !=3.4, !=3.5, !=3.6
+python_requires = >=3.7
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ package_dir =
 packages = find:
 include_package_data = true
 zip_safe = false
+python_requires = >=2.7, !=3.0, !=3.1, !=3.2, !=3.3, !=3.4, !=3.5, !=3.6
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Resolvelib is not maintained for Python prior to 3.7. It was pointed out in #116.

Resolves #122