### PR TITLE
[minor] Improve exception chaining

### DIFF
--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -315,7 +315,7 @@ class Resolution(object):
                     broken_state = self._states.pop()
                     name, candidate = broken_state.mapping.popitem()
                 except (IndexError, KeyError):
-                    raise ResolutionImpossible(causes)
+                    raise ResolutionImpossible(causes) from None
                 current_dependencies = {
                     self._p.identify(d)
                     for d in self._p.get_dependencies(candidate)


### PR DESCRIPTION
This will clean up the following stacktrace a little
```
Traceback (most recent call last):
  File "/Users/shantanu/.local/pipx/shared/lib/python3.9/site-packages/pip/_vendor/resolvelib/resolvers.py", line 316, in _backjump
    name, candidate = broken_state.mapping.popitem()
KeyError: 'dictionary is empty'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/shantanu/.local/pipx/shared/lib/python3.9/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 92, in resolve
    result = self._result = resolver.resolve(
  File "/Users/shantanu/.local/pipx/shared/lib/python3.9/site-packages/pip/_vendor/resolvelib/resolvers.py", line 546, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "/Users/shantanu/.local/pipx/shared/lib/python3.9/site-packages/pip/_vendor/resolvelib/resolvers.py", line 434, in resolve
    success = self._backjump(causes)
  File "/Users/shantanu/.local/pipx/shared/lib/python3.9/site-packages/pip/_vendor/resolvelib/resolvers.py", line 318, in _backjump
    raise ResolutionImpossible(causes)
pip._vendor.resolvelib.resolvers.ResolutionImpossible: [ ... ]
```