### PR TITLE
add required arg `backtrack_causes` to `get_preferences()` override

### DIFF
--- a/examples/reporter_demo.py
+++ b/examples/reporter_demo.py
@@ -73,7 +73,7 @@ class Provider(resolvelib.AbstractProvider):
     def identify(self, requirement_or_candidate):
         return requirement_or_candidate.name
 
-    def get_preference(self, identifier, resolutions, candidates, information):
+    def get_preference(self, identifier, resolutions, candidates, information, backtrack_causes):
         return sum(1 for _ in candidates[identifier])
 
     def find_matches(self, identifier, requirements, incompatibilities):

--- a/examples/reporter_demo.py
+++ b/examples/reporter_demo.py
@@ -73,7 +73,14 @@ class Provider(resolvelib.AbstractProvider):
     def identify(self, requirement_or_candidate):
         return requirement_or_candidate.name
 
-    def get_preference(self, identifier, resolutions, candidates, information, backtrack_causes):
+    def get_preference(
+        self,
+        identifier,
+        resolutions,
+        candidates,
+        information,
+        backtrack_causes,
+    ):
         return sum(1 for _ in candidates[identifier])
 
     def find_matches(self, identifier, requirements, incompatibilities):


### PR DESCRIPTION
backtrack_causes is a required argument in get_preferences, as defined by the parent class resolvelib.AbstractProvider. Adding this argument allows the example to run without errors.