### PR TITLE
Replace the commentjson test dependency with re.sub

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,6 @@ lint =
 	isort
 	types-requests
 test =
-	commentjson
 	packaging
 	pytest
 release =

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -5,7 +5,6 @@ import os
 import re
 import string
 
-import commentjson  # type: ignore
 import pytest
 
 from resolvelib import AbstractProvider, ResolutionImpossible, Resolver
@@ -124,14 +123,18 @@ def _version_in_specset(version, specset):
 
 
 def _safe_json_load(filename):
-    # Some fixtures has comments so the stdlib implementation doesn't work.
-    # We only use commentjson if we absolutely need to because it's SLOW.
-    try:
-        with open(filename) as f:
+    # Some fixtures have comments so they are not valid json.
+    # We could use commentjson/json5 to load them,
+    # but it's easier to strip the comments.
+    # We only do it when json.load() fails to avoid unnecessary loading
+    # all the json files to strings.
+    with open(filename) as f:
+        try:
             data = json.load(f)
-    except ValueError:
-        with open(filename) as f:
-            data = commentjson.load(f)
+        except ValueError:
+            f.seek(0)
+            strippedjson = re.sub(r"//.*$", "", f.read(), flags=re.MULTILINE)
+            data = json.loads(strippedjson)
     return data
 
 

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -124,7 +124,8 @@ def _version_in_specset(version, specset):
 
 def _safe_json_load(filename):
     # Some fixtures have comments, so strip them if first parse fails.
-    # We only do this in case of failure to avoid loading all JSON files to strings before parsing.
+    # We only do this in case of failure to avoid loading all JSON files to
+    # strings before parsing.
     with open(filename) as f:
         try:
             data = json.load(f)

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -123,11 +123,8 @@ def _version_in_specset(version, specset):
 
 
 def _safe_json_load(filename):
-    # Some fixtures have comments so they are not valid json.
-    # We could use commentjson/json5 to load them,
-    # but it's easier to strip the comments.
-    # We only do it when json.load() fails to avoid unnecessary loading
-    # all the json files to strings.
+    # Some fixtures have comments, so strip them if first parse fails.
+    # We only do this in case of failure to avoid loading all JSON files to strings before parsing.
     with open(filename) as f:
         try:
             data = json.load(f)


### PR DESCRIPTION
While at it, only open the json files once.

(This is motivated by Fedora, when we don't have commentjson packaged. Currently, we use json5 instead, but while looking at that @yselkowitz figured out we can pre-process the files instead.)