### PR TITLE
Deduplicate causes

### DIFF
--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -381,6 +381,14 @@ class Resolution(Generic[RT, CT, KT]):
         # No way to backtrack anymore.
         return False
 
+    def _extract_causes(
+        self, criteron: list[Criterion[RT, CT]]
+    ) -> list[RequirementInformation[RT, CT]]:
+        """Extract causes from list of criterion and deduplicate"""
+        return list(
+            {id(i): i for c in criteron for i in c.information}.values()
+        )
+
     def resolve(
         self, requirements: Iterable[RT], max_rounds: int
     ) -> State[RT, CT, KT]:
@@ -429,10 +437,10 @@ class Resolution(Generic[RT, CT, KT]):
 
             # Choose the most preferred unpinned criterion to try.
             name = min(unsatisfied_names, key=self._get_preference)
-            failure_causes = self._attempt_to_pin_criterion(name)
+            failure_criterion = self._attempt_to_pin_criterion(name)
 
-            if failure_causes:
-                causes = [i for c in failure_causes for i in c.information]
+            if failure_criterion:
+                causes = self._extract_causes(failure_criterion)
                 # Backjump if pinning fails. The backjump process puts us in
                 # an unpinned state, so we can work on it in the next round.
                 self._r.resolving_conflicts(causes=causes)


### PR DESCRIPTION
This is a relatively small thing, but I noticed when you have large backtracking trees the causes list often contains many duplicates and can sometimes be significantly reduced in size (>50%) by deduplicating it.

This saves a bit of memory and some time for any part of the resolution process that is iterating through causes.