### PR TITLE
Add intelligent fallback from backjump to backtrack

### DIFF
--- a/src/resolvelib/reporters.py
+++ b/src/resolvelib/reporters.py
@@ -60,3 +60,6 @@ class BaseReporter(Generic[RT, CT, KT]):
 
     def pinning(self, candidate: CT) -> None:
         """Called when adding a candidate to the potential solution."""
+
+    def fallback_activated(self) -> None:
+        """Called when falling back from backjumping to backtracking."""

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections
 import itertools
 import operator
+from copy import copy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -122,11 +123,7 @@ class Resolution(Generic[RT, CT, KT]):
         coming round.
         """
         base = self._states[-1]
-        state = State(
-            mapping=base.mapping.copy(),
-            criteria=base.criteria.copy(),
-            backtrack_causes=base.backtrack_causes[:],
-        )
+        state = copy(base)
         self._states.append(state)
 
     def _add_to_criteria(
@@ -274,14 +271,7 @@ class Resolution(Generic[RT, CT, KT]):
 
     def _copy_all_states(self) -> list[State]:
         """Create a copy of the all the current states"""
-        return [
-            State(
-                s.mapping.copy(),
-                s.criteria.copy(),
-                s.backtrack_causes[:],
-            )
-            for s in self._states
-        ]
+        return [copy(s) for s in self._states]
 
     def _backtrack_iteration(self) -> tuple[KT, CT, list[tuple[KT, list[CT]]]]:
         """

--- a/src/resolvelib/structs.py
+++ b/src/resolvelib/structs.py
@@ -37,11 +37,27 @@ if TYPE_CHECKING:
         criteria: dict[KT, Criterion[RT, CT]]
         backtrack_causes: list[RequirementInformation[RT, CT]]
 
+        def __copy__(self) -> State:
+            ...
+
 else:
     RequirementInformation = namedtuple(
         "RequirementInformation", ["requirement", "parent"]
     )
-    State = namedtuple("State", ["mapping", "criteria", "backtrack_causes"])
+
+    class State(NamedTuple):
+        """Resolution state in a round."""
+
+        mapping: dict
+        criteria: dict
+        backtrack_causes: list
+
+        def __copy__(self) -> "State":
+            return State(
+                mapping=self.mapping.copy(),
+                criteria=self.criteria.copy(),
+                backtrack_causes=self.backtrack_causes[:],
+            )
 
 
 class DirectedGraph(Generic[KT]):


### PR DESCRIPTION
Fixes https://github.com/sarugaku/resolvelib/issues/134

Alternative to https://github.com/sarugaku/resolvelib/pull/142, fixes both the requirments mentioned here https://github.com/sarugaku/resolvelib/pull/142#issuecomment-1811627400

I beleive this strategy is fairly foolproof:

1. When backjumping make a backup of the states the first time backjumping skips over states further than backtracking would
2. If backjumping reaches resolution impossible and a backup state exists, fall back to that state and start backtracking

However, there are downsides, it could definetly cause a valid ResolutionImpossible to take much longer to produce. I have therefore give the calling library a choice on what to do, backjump with backtrack fallback, backjump only, or backtrack only.

If you want tests I need some small guidance, I don't really understand this repos tests.

Let me know what you think!