### PR TITLE
Allow provider to filter unsatisfied names, when backtracking

### DIFF
--- a/news/145.feature
+++ b/news/145.feature
@@ -1,0 +1,3 @@
+New `narrow_requirement_selection` provider method giving option for
+providers to reduce the number of times sort key `get_preference` is
+called in long running backtrack

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ exclude = [
 	"*.pyi"
 ]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 12
+
 [tool.mypy]
 warn_unused_configs = true
 

--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -40,13 +40,12 @@ class AbstractProvider(Generic[RT, CT, KT]):
     ) -> Preference:
         """Produce a sort key for given requirement based on preference.
 
-        As this is a sort key it will be called O(n) times per backtrack step,
-        where n is the number of `identifier`s. If you have a check which is
-        expensive in some sense, e.g. it needs to make O(n) checks per
-        identifier, or takes significant wall clock time but could be short
-        circuited once finding an identifier that matches the check, consider
-        using `narrow_requirement_selection` to filter the `identifier`s
-        before this sort key is called.
+        As this is a sort key it will be called O(n) times per backtrack
+        step, where n is the number of `identifier`s, if you have a check
+        which is expensive in some sense. E.g. It needs to make O(n) checks
+        per call or takes significant wall clock time, consider using
+        `narrow_requirement_selection` to filter the `identifier`s, which
+        is applied before this sort key is called.
 
         The preference is defined as "I think this requirement should be
         resolved first". The lower the return value is, the more preferred

--- a/src/resolvelib/resolvers/resolution.py
+++ b/src/resolvelib/resolvers/resolution.py
@@ -430,6 +430,10 @@ class Resolution(Generic[RT, CT, KT]):
             else:
                 narrowed_unstatisfied_names = unsatisfied_names
 
+            # If there are no unsatisfied names use unsatisfied names
+            if not narrowed_unstatisfied_names:
+                raise RuntimeError("narrow_requirement_selection returned 0 names")
+
             # If there is only 1 unsatisfied name skip calling self._get_preference
             if len(narrowed_unstatisfied_names) > 1:
                 # Choose the most preferred unpinned criterion to try.

--- a/src/resolvelib/resolvers/resolution.py
+++ b/src/resolvelib/resolvers/resolution.py
@@ -433,9 +433,7 @@ class Resolution(Generic[RT, CT, KT]):
             # If there is only 1 unsatisfied name skip calling self._get_preference
             if len(narrowed_unstatisfied_names) > 1:
                 # Choose the most preferred unpinned criterion to try.
-                name = min(
-                    narrowed_unstatisfied_names, key=self._get_preference
-                )
+                name = min(narrowed_unstatisfied_names, key=self._get_preference)
             else:
                 name = narrowed_unstatisfied_names[0]
 


### PR DESCRIPTION
This allows the provider to optimize the steps it takes to choose what to backtrack on.

Specifically the aim is to add preferring conflicting causes in Pip without the overhead of recalculating or caching each time `get_preference` is called. I initially wanted to do a lot of this "preferring" work in resolvelib itself, but upon inspecting the resolution types I realized there was no guarantee of required information (which would have been a problem if this previous PR had landed https://github.com/sarugaku/resolvelib/pull/132).

I have a Pip branch that implements this filtering: https://github.com/notatallshaw/pip/blob/prefer-conflicting-causes/src/pip/_internal/resolution/resolvelib/provider.py#L240. Which on Python 3.8 allows it to solve the following requirement which currently produces a "ResolutionTooDeep" error: `--only-binary ":all:" "numpy==1.21.6" "cython==0.29.28" "scipy>=1.4.0" "torch>=1.7" "torchaudio" "soundfile" "librosa==0.10.0.*" "numba==0.55.1" "inflect==5.6.0" "tqdm" "anyascii" "pyyaml" "fsspec>=2021.04.0" "aiohttp" "packaging" "flask" "pysbd" "pandas" "matplotlib" "trainer==0.0.20" "coqpit>=0.0.16" "pypinyin" "mecab-python3==1.0.5" "jamo" "bangla==0.0.2" "k_diffusion" "einops" "transformers"`

