### PR TITLE
Separate `AbstractResolver` and `Resolver` into different modules

### DIFF
--- a/src/resolvelib/__init__.py
+++ b/src/resolvelib/__init__.py
@@ -16,8 +16,8 @@ __version__ = "1.0.2.dev0"
 
 from .providers import AbstractProvider
 from .reporters import BaseReporter
-from .resolvers import (
-    AbstractResolver,
+from .resolvers.abstract import AbstractResolver
+from .resolvers.criterion import (
     InconsistentCandidate,
     RequirementsConflicted,
     ResolutionError,

--- a/src/resolvelib/resolvers/__init__.py
+++ b/src/resolvelib/resolvers/__init__.py
@@ -1,0 +1,10 @@
+from ..structs import RequirementInformation
+from .abstract import AbstractResolver, Result
+from .criterion import (
+    InconsistentCandidate,
+    RequirementsConflicted,
+    ResolutionError,
+    ResolutionImpossible,
+    ResolutionTooDeep,
+    ResolverException,
+)

--- a/src/resolvelib/resolvers/abstract.py
+++ b/src/resolvelib/resolvers/abstract.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import collections
+from typing import TYPE_CHECKING, Any, Generic, Iterable, Mapping, NamedTuple
+
+from resolvelib.providers import AbstractProvider
+from resolvelib.reporters import BaseReporter
+
+from ..structs import CT, KT, RT, Criterion, DirectedGraph
+
+if TYPE_CHECKING:
+
+    class Result(NamedTuple, Generic[RT, CT, KT]):
+        mapping: Mapping[KT, CT]
+        graph: DirectedGraph[KT | None]
+        criteria: Mapping[KT, Criterion[RT, CT]]
+
+else:
+    Result = collections.namedtuple("Result", ["mapping", "graph", "criteria"])
+
+
+class AbstractResolver(Generic[RT, CT, KT]):
+    """The thing that performs the actual resolution work."""
+
+    base_exception = Exception
+
+    def __init__(
+        self,
+        provider: AbstractProvider[RT, CT, KT],
+        reporter: BaseReporter[RT, CT, KT],
+    ) -> None:
+        self.provider = provider
+        self.reporter = reporter
+
+    def resolve(
+        self, requirements: Iterable[RT], **kwargs: Any
+    ) -> Result[RT, CT, KT]:
+        """Take a collection of constraints, spit out the resolution result.
+
+        This returns a representation of the final resolution state, with one
+        guarenteed attribute ``mapping`` that contains resolved candidates as
+        values. The keys are their respective identifiers.
+
+        :param requirements: A collection of constraints.
+        :param kwargs: Additional keyword arguments that subclasses may accept.
+
+        :raises: ``self.base_exception`` or its subclass.
+        """
+        raise NotImplementedError

--- a/src/resolvelib/resolvers/criterion.py
+++ b/src/resolvelib/resolvers/criterion.py
@@ -3,19 +3,11 @@ from __future__ import annotations
 import collections
 import itertools
 import operator
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Collection,
-    Generic,
-    Iterable,
-    Mapping,
-    NamedTuple,
-)
+from typing import TYPE_CHECKING, Collection, Generic, Iterable, Mapping
 
-from .providers import AbstractProvider
-from .reporters import BaseReporter
-from .structs import (
+from ..providers import AbstractProvider
+from ..reporters import BaseReporter
+from ..structs import (
     CT,
     KT,
     RT,
@@ -27,17 +19,10 @@ from .structs import (
     State,
     build_iter_view,
 )
+from .abstract import AbstractResolver, Result
 
 if TYPE_CHECKING:
-    from .providers import Preference
-
-    class Result(NamedTuple, Generic[RT, CT, KT]):
-        mapping: Mapping[KT, CT]
-        graph: DirectedGraph[KT | None]
-        criteria: Mapping[KT, Criterion[RT, CT]]
-
-else:
-    Result = collections.namedtuple("Result", ["mapping", "graph", "criteria"])
+    from ..providers import Preference
 
 
 class ResolverException(Exception):
@@ -523,36 +508,6 @@ def _build_result(state: State[RT, CT, KT]) -> Result[RT, CT, KT]:
         graph=graph,
         criteria=state.criteria,
     )
-
-
-class AbstractResolver(Generic[RT, CT, KT]):
-    """The thing that performs the actual resolution work."""
-
-    base_exception = Exception
-
-    def __init__(
-        self,
-        provider: AbstractProvider[RT, CT, KT],
-        reporter: BaseReporter[RT, CT, KT],
-    ) -> None:
-        self.provider = provider
-        self.reporter = reporter
-
-    def resolve(
-        self, requirements: Iterable[RT], **kwargs: Any
-    ) -> Result[RT, CT, KT]:
-        """Take a collection of constraints, spit out the resolution result.
-
-        This returns a representation of the final resolution state, with one
-        guarenteed attribute ``mapping`` that contains resolved candidates as
-        values. The keys are their respective identifiers.
-
-        :param requirements: A collection of constraints.
-        :param kwargs: Additional keyword arguments that subclasses may accept.
-
-        :raises: ``self.base_exception`` or its subclass.
-        """
-        raise NotImplementedError
 
 
 class Resolver(AbstractResolver[RT, CT, KT]):

--- a/tests/functional/swift-package-manager/test_resolvers_swift.py
+++ b/tests/functional/swift-package-manager/test_resolvers_swift.py
@@ -5,8 +5,8 @@ import os
 
 import pytest
 
+from resolvelib import Resolver
 from resolvelib.providers import AbstractProvider
-from resolvelib.resolvers import Resolver
 
 Requirement = collections.namedtuple("Requirement", "container constraint")
 Candidate = collections.namedtuple("Candidate", "container version")

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
+from collections import namedtuple
 from typing import TYPE_CHECKING, Any, Iterator, Sequence, Tuple
-
-if TYPE_CHECKING:
-    from typing import Iterable, Mapping
 
 import pytest
 from packaging.requirements import Requirement
@@ -16,17 +14,16 @@ from resolvelib import (
     ResolutionImpossible,
     Resolver,
 )
+from resolvelib.resolvers import Resolution
 
 if TYPE_CHECKING:
+    from typing import Iterable, Mapping
+
     from resolvelib.resolvers import (
         Criterion,
         RequirementInformation,
         RequirementsConflicted,
     )
-
-from collections import namedtuple
-
-from resolvelib.resolvers import Resolution
 
 
 def test_candidate_inconsistent_error():

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -14,12 +14,12 @@ from resolvelib import (
     ResolutionImpossible,
     Resolver,
 )
-from resolvelib.resolvers import Resolution
+from resolvelib.resolvers.criterion import Resolution
 
 if TYPE_CHECKING:
     from typing import Iterable, Mapping
 
-    from resolvelib.resolvers import (
+    from resolvelib.resolvers.criterion import (
         Criterion,
         RequirementInformation,
         RequirementsConflicted,
@@ -261,7 +261,7 @@ def test_pin_conflict_with_self(monkeypatch, reporter):
     result = resolver.resolve(["child", "parent"])
 
     def get_child_versions(
-        information: Iterable[RequirementInformation[str, Candidate]]
+        information: Iterable[RequirementInformation[str, Candidate]],
     ) -> set[str]:
         return {
             str(inf.parent[1])


### PR DESCRIPTION
I started looking into porting an existing SAT solver, but this lack of separation makes it non-trivial to organise the relevant code.

Making this change to simplify that, as well as create a more explicit separation of abstract vs concrete here.

---

This PR is best reviewed commit-by-commit. :)
