### PR TITLE
Fix CI: Pin Black version for linting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ examples =
 	pygraphviz
 	requests
 lint =
-	black
+	black==23.12.1
 	flake8
 	mypy
 	isort


### PR DESCRIPTION
Black 24.1.0 has updated the formatting style and it changes several things in the resolvelib codebase: https://github.com/psf/black/releases/tag/24.1.0

In providers.py it changes:

```python
    class Preference(Protocol):
        def __lt__(self, __other: Any) -> bool:
            ...
```

To:
```python
    class Preference(Protocol):
        def __lt__(self, __other: Any) -> bool: ...
```

Which fails the flake8 rule "E704 multiple statements on one line (def)". I am therefore pinning the black version so it does not impact other PRs, and does not fight with flake8. Also in general it makes sense to pin your formatting tool so these breakages don't happen.

I'd also be happy to do a follow up PR that moves the linting and formatting config to `ruff` if the resolvelib maintainers view this as a good idea. 