### PR TITLE
Run tests against Python 3.12, 3.13, and use latest version of CI dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,35 +9,38 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - run: pip install nox
       - run: nox -s lint
   package:
     name: Package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - run: pip install nox
       - run: nox -s release -- --version '' --repo '' --prebump ''
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [lint]
     strategy:
       fail-fast: true
       matrix:
         python:
+          - "3.13"
+          - "3.12"
           - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"
           - "3.7"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - run: pip install nox
       - run: nox -s tests-${{ matrix.python }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ def lint(session):
     session.run("mypy", "src", "tests")
 
 
-@nox.session(python=["3.11", "3.10", "3.9", "3.8", "3.7", "2.7"])
+@nox.session(python=["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7"])
 def tests(session):
     session.install(".[test]")
 


### PR DESCRIPTION
Makes sure latest actions, OSes, and Python are being tested against.