### PR TITLE
Backjumping failures

### DIFF
--- a/tests/functional/python/inputs/case/issue-134-2.json
+++ b/tests/functional/python/inputs/case/issue-134-2.json
@@ -1,0 +1,15 @@
+{
+	"index": "issue-134-2",
+	"requested": [
+		"parent"
+	],
+	"resolved": {
+		"parent": "0.0.1",
+		"pandas": "1.3.5",
+		"pystac": "1.8.3",
+		"pystac-client": "0.3.3",
+		"sat-stac": "0.1.1",
+		"python-dateutil": "2.7.5",
+		"requests": "2.31.0"
+	}
+}

--- a/tests/functional/python/inputs/case/issue-134-3.json
+++ b/tests/functional/python/inputs/case/issue-134-3.json
@@ -1,0 +1,17 @@
+{
+	"index": "issue-134-3",
+	"requested": [
+		"a"
+	],
+	"resolved": {
+		"a": "0.0.1",
+		"b": "0.0.2",
+		"c": "0.0.1",
+		"pandas": "1.3.5",
+		"pystac": "1.8.3",
+		"pystac-client": "0.3.3",
+		"sat-stac": "0.1.1",
+		"python-dateutil": "2.7.5",
+		"requests": "2.31.0"
+	}
+}

--- a/tests/functional/python/inputs/index/issue-134-2.json
+++ b/tests/functional/python/inputs/index/issue-134-2.json
@@ -1,0 +1,76 @@
+{
+    "parent": {
+        "0.0.1": {
+            "dependencies": [
+                "pandas<=1.4.0,>=1.3.5",
+                "pystac<=1.8.3,>=1.8.2",
+                "pystac-client<=0.3.3,>=0.3.2",
+                "sat-stac<=0.1.1"
+            ]
+        }
+    },
+    "pandas": {
+        "1.4.0": {
+            "dependencies": [
+                "python-dateutil (>=2.8.1)"
+            ]
+        },
+        "1.3.5": {
+            "dependencies": [
+                "python-dateutil (>=2.7.3)"
+            ]
+        }
+    },
+    "pystac": {
+        "1.8.3": {
+            "dependencies": [
+                "python-dateutil (>=2.7.0)"
+            ]
+        },
+        "1.8.2": {
+            "dependencies": [
+                "python-dateutil (>=2.7.0)"
+            ]
+        }
+    },
+    "pystac-client": {
+        "0.3.3": {
+            "dependencies": [
+                "requests (>=2.25)",
+                "pystac (>=1.4.0)"
+            ]
+        },
+        "0.3.2": {
+            "dependencies": [
+                "requests (>=2.25)",
+                "pystac (~=1.2.0)"
+            ]
+        }
+    },
+    "sat-stac": {
+        "0.1.1": {
+            "dependencies": [
+                "python-dateutil (~=2.7.5)"
+            ]
+        },
+        "0.1.0": {
+            "dependencies": [
+                "requests (~=2.19.1)",
+                "python-dateutil (~=2.7.5)"
+            ]
+        }
+    },
+    "python-dateutil": {
+        "2.9.0": {
+            "dependencies": []
+        },
+        "2.7.5": {
+            "dependencies": []
+        }
+    },
+    "requests": {
+        "2.31.0": {
+            "dependencies": []
+        }
+    }
+}

--- a/tests/functional/python/inputs/index/issue-134-3.json
+++ b/tests/functional/python/inputs/index/issue-134-3.json
@@ -1,0 +1,92 @@
+{
+    "a": {
+        "0.0.1": {
+            "dependencies": [
+                "b",
+                "c"
+            ]
+        }
+    },
+    "b": {
+        "0.0.1": {
+            "dependencies": []
+        },
+        "0.0.2": {
+            "dependencies": []
+        }
+    },
+    "c": {
+        "0.0.1": {
+            "dependencies": [
+                "pandas<=1.4.0,>=1.3.5",
+                "pystac<=1.8.3,>=1.8.2",
+                "pystac-client<=0.3.3,>=0.3.2",
+                "sat-stac<=0.1.1"
+            ]
+        }
+    },
+    "pandas": {
+        "1.4.0": {
+            "dependencies": [
+                "python-dateutil (>=2.8.1)"
+            ]
+        },
+        "1.3.5": {
+            "dependencies": [
+                "python-dateutil (>=2.7.3)"
+            ]
+        }
+    },
+    "pystac": {
+        "1.8.3": {
+            "dependencies": [
+                "python-dateutil (>=2.7.0)"
+            ]
+        },
+        "1.8.2": {
+            "dependencies": [
+                "python-dateutil (>=2.7.0)"
+            ]
+        }
+    },
+    "pystac-client": {
+        "0.3.3": {
+            "dependencies": [
+                "requests (>=2.25)",
+                "pystac (>=1.4.0)"
+            ]
+        },
+        "0.3.2": {
+            "dependencies": [
+                "requests (>=2.25)",
+                "pystac (~=1.2.0)"
+            ]
+        }
+    },
+    "sat-stac": {
+        "0.1.1": {
+            "dependencies": [
+                "python-dateutil (~=2.7.5)"
+            ]
+        },
+        "0.1.0": {
+            "dependencies": [
+                "requests (~=2.19.1)",
+                "python-dateutil (~=2.7.5)"
+            ]
+        }
+    },
+    "python-dateutil": {
+        "2.9.0": {
+            "dependencies": []
+        },
+        "2.7.5": {
+            "dependencies": []
+        }
+    },
+    "requests": {
+        "2.31.0": {
+            "dependencies": []
+        }
+    }
+}


### PR DESCRIPTION
Here are two tests (I may add more) that fail because of backjumping.

None of these tests are fixed by https://github.com/sarugaku/resolvelib/pull/152 because that is only able to recover the situation if each requirement has remaining unchecked candidates, but backjumping can backtrack to the root requirement, incorrectly, and if, for example, that requirement has only one candidate then there can be an erroneous ResolutionImpossible.

I *believe* the issue is that backjumping sets up an implicit contract, caused by [this](https://github.com/sarugaku/resolvelib/blob/main/src/resolvelib/resolvers.py#L326), between itself and the provider. That the provider should always prefer direct conflicts over any other candidate. However, resolvelib does not enforce or document this, and the provider can prefer any unsatisfied name, and therefore the algorithm is currently unsound, for example pip does not prefer directly conflicting packages, at least not [yet](https://github.com/pypa/pip/pull/12499).

@uranusjr @frostming @bennati IMO either backjumping should be reverted, or it should be made opt-in for providers who "know what they are doing".