### PR TITLE
Only backjump if the current broken state is an incompatible dependency

### DIFF
--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -319,6 +319,11 @@ class Resolution(Generic[RT, CT, KT]):
                 except (IndexError, KeyError):
                     raise ResolutionImpossible(causes) from None
 
+                # Only backjump if the current broken state is
+                # an incompatible dependency
+                if name not in incompatible_deps:
+                    break
+
                 # If the current dependencies and the incompatible dependencies
                 # are overlapping then we have found a cause of the incompatibility
                 current_dependencies = {

--- a/tests/functional/python/inputs/case/backjump-test-1.json
+++ b/tests/functional/python/inputs/case/backjump-test-1.json
@@ -1,0 +1,15 @@
+{
+	"index": "backjump-test-1",
+	"requested": [
+		"parent"
+	],
+	"resolved": {
+		"parent": "0.0.1",
+		"pandas": "1.3.5",
+		"pystac": "1.8.3",
+		"pystac-client": "0.3.3",
+		"sat-stac": "0.1.1",
+		"python-dateutil": "2.7.5",
+		"requests": "2.31.0"
+	}
+}

--- a/tests/functional/python/inputs/case/backjump-test-2.json
+++ b/tests/functional/python/inputs/case/backjump-test-2.json
@@ -1,0 +1,17 @@
+{
+	"index": "backjump-test-2",
+	"requested": [
+		"a"
+	],
+	"resolved": {
+		"a": "0.0.1",
+		"b": "0.0.2",
+		"c": "0.0.1",
+		"pandas": "1.3.5",
+		"pystac": "1.8.3",
+		"pystac-client": "0.3.3",
+		"sat-stac": "0.1.1",
+		"python-dateutil": "2.7.5",
+		"requests": "2.31.0"
+	}
+}

--- a/tests/functional/python/inputs/index/backjump-test-1.json
+++ b/tests/functional/python/inputs/index/backjump-test-1.json
@@ -1,0 +1,76 @@
+{
+    "parent": {
+        "0.0.1": {
+            "dependencies": [
+                "pandas<=1.4.0,>=1.3.5",
+                "pystac<=1.8.3,>=1.8.2",
+                "pystac-client<=0.3.3,>=0.3.2",
+                "sat-stac<=0.1.1"
+            ]
+        }
+    },
+    "pandas": {
+        "1.4.0": {
+            "dependencies": [
+                "python-dateutil (>=2.8.1)"
+            ]
+        },
+        "1.3.5": {
+            "dependencies": [
+                "python-dateutil (>=2.7.3)"
+            ]
+        }
+    },
+    "pystac": {
+        "1.8.3": {
+            "dependencies": [
+                "python-dateutil (>=2.7.0)"
+            ]
+        },
+        "1.8.2": {
+            "dependencies": [
+                "python-dateutil (>=2.7.0)"
+            ]
+        }
+    },
+    "pystac-client": {
+        "0.3.3": {
+            "dependencies": [
+                "requests (>=2.25)",
+                "pystac (>=1.4.0)"
+            ]
+        },
+        "0.3.2": {
+            "dependencies": [
+                "requests (>=2.25)",
+                "pystac (~=1.2.0)"
+            ]
+        }
+    },
+    "sat-stac": {
+        "0.1.1": {
+            "dependencies": [
+                "python-dateutil (~=2.7.5)"
+            ]
+        },
+        "0.1.0": {
+            "dependencies": [
+                "requests (~=2.19.1)",
+                "python-dateutil (~=2.7.5)"
+            ]
+        }
+    },
+    "python-dateutil": {
+        "2.9.0": {
+            "dependencies": []
+        },
+        "2.7.5": {
+            "dependencies": []
+        }
+    },
+    "requests": {
+        "2.31.0": {
+            "dependencies": []
+        }
+    }
+}

--- a/tests/functional/python/inputs/index/backjump-test-2.json
+++ b/tests/functional/python/inputs/index/backjump-test-2.json
@@ -1,0 +1,92 @@
+{
+    "a": {
+        "0.0.1": {
+            "dependencies": [
+                "b",
+                "c"
+            ]
+        }
+    },
+    "b": {
+        "0.0.1": {
+            "dependencies": []
+        },
+        "0.0.2": {
+            "dependencies": []
+        }
+    },
+    "c": {
+        "0.0.1": {
+            "dependencies": [
+                "pandas<=1.4.0,>=1.3.5",
+                "pystac<=1.8.3,>=1.8.2",
+                "pystac-client<=0.3.3,>=0.3.2",
+                "sat-stac<=0.1.1"
+            ]
+        }
+    },
+    "pandas": {
+        "1.4.0": {
+            "dependencies": [
+                "python-dateutil (>=2.8.1)"
+            ]
+        },
+        "1.3.5": {
+            "dependencies": [
+                "python-dateutil (>=2.7.3)"
+            ]
+        }
+    },
+    "pystac": {
+        "1.8.3": {
+            "dependencies": [
+                "python-dateutil (>=2.7.0)"
+            ]
+        },
+        "1.8.2": {
+            "dependencies": [
+                "python-dateutil (>=2.7.0)"
+            ]
+        }
+    },
+    "pystac-client": {
+        "0.3.3": {
+            "dependencies": [
+                "requests (>=2.25)",
+                "pystac (>=1.4.0)"
+            ]
+        },
+        "0.3.2": {
+            "dependencies": [
+                "requests (>=2.25)",
+                "pystac (~=1.2.0)"
+            ]
+        }
+    },
+    "sat-stac": {
+        "0.1.1": {
+            "dependencies": [
+                "python-dateutil (~=2.7.5)"
+            ]
+        },
+        "0.1.0": {
+            "dependencies": [
+                "requests (~=2.19.1)",
+                "python-dateutil (~=2.7.5)"
+            ]
+        }
+    },
+    "python-dateutil": {
+        "2.9.0": {
+            "dependencies": []
+        },
+        "2.7.5": {
+            "dependencies": []
+        }
+    },
+    "requests": {
+        "2.31.0": {
+            "dependencies": []
+        }
+    }
+}


### PR DESCRIPTION
This appears to fix backjumping, in all cases, while keeping the performance benefits.

I do not have an intuitive explanation, but I created a series of tests and printed out debugging information and looked at when the current backjumping made the wrong choice, and it was always when the current broken state's name was not in the incompatible dependencies.

I have added two tests that currently fail that I constructed from my understanding of when the problem occurs.

I have created another test, not in this PR, based on `kedro[test]==0.18.13`, however the JSON is **massive** (450k lines), and it would require a better [`get_preference`](https://github.com/sarugaku/resolvelib/blob/1.0.1/tests/functional/python/test_resolvers_python.py#L74 ) to complete in a reasonable number of rounds. Let me know if you want me to try and get that test working for this or another PR. 
