### PR TITLE
Add unvisited tests to ensure backjumping

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,13 +8,16 @@ from resolvelib import BaseReporter
 class TestReporter(BaseReporter):
     def __init__(self):
         self._indent = 0
+        self.visited = []
 
     def rejecting_candidate(self, criterion, candidate):
         self._indent -= 1
+        self.visited.append(candidate)
         print(" " * self._indent, "Reject ", candidate, sep="")
 
     def pinning(self, candidate):
         print(" " * self._indent, "Pin  ", candidate, sep="")
+        self.visited.append(candidate)
         self._indent += 1
 
 

--- a/tests/functional/python/inputs/case/backjump-test-1.json
+++ b/tests/functional/python/inputs/case/backjump-test-1.json
@@ -11,5 +11,8 @@
 		"sat-stac": "0.1.1",
 		"python-dateutil": "2.7.5",
 		"requests": "2.31.0"
+	},
+	"unvisited": {
+		"pystac": ["1.8.2"]
 	}
 }

--- a/tests/functional/python/inputs/case/backjump-test-2.json
+++ b/tests/functional/python/inputs/case/backjump-test-2.json
@@ -13,5 +13,8 @@
 		"sat-stac": "0.1.1",
 		"python-dateutil": "2.7.5",
 		"requests": "2.31.0"
+	},
+	"unvisited": {
+		"pystac": ["1.8.2"]
 	}
 }

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -195,4 +195,4 @@ def test_resolver(provider, reporter):
             )
             assert (
                 not unexpected_versions
-            ), f"Unexpcted versions visited for {name}: {', '.join(unexpected_versions)}"
+            ), f"Unexpcted versions visited {name}: {', '.join(unexpected_versions)}"


### PR DESCRIPTION
This adds a new category of functional tests for the Pip Provider which is meant to ensure that backjumping is not accidentally broken.

It checks that certain candidates were never visited, because if backjumping is behaving as expected the path to visit them should have never been taken.

Both test cases added here fail if you remove backjumping.

Later it would be worth adding more of these, in particular I have been work on using "kedro" as a real test case, but am having issues with both py2index and pip-resolver-benchmarks (i.e. pip resolves the real world case but doesn't resolve the version captured by either of these tools), if I ever figure it out I will add more test cases.
