### PR TITLE
Switch from flake8 to ruff - and run various linting cleanups

### DIFF
--- a/examples/extras_provider.py
+++ b/examples/extras_provider.py
@@ -39,7 +39,7 @@ class ExtrasProvider(AbstractProvider):
         raise NotImplementedError
 
     def identify(self, requirement_or_candidate):
-        base = super(ExtrasProvider, self).identify(requirement_or_candidate)
+        base = super().identify(requirement_or_candidate)
         extras = self.get_extras_for(requirement_or_candidate)
         if extras:
             return (base, extras)
@@ -47,7 +47,7 @@ class ExtrasProvider(AbstractProvider):
             return base
 
     def get_dependencies(self, candidate):
-        deps = super(ExtrasProvider, self).get_dependencies(candidate)
+        deps = super().get_dependencies(candidate)
         if candidate.extras:
             req = self.get_base_requirement(candidate)
             deps.append(req)

--- a/examples/pypi_wheel_provider.py
+++ b/examples/pypi_wheel_provider.py
@@ -68,7 +68,7 @@ class Candidate:
 
 def get_project_from_pypi(project, extras):
     """Return candidates created from the project name and extras."""
-    url = "https://pypi.org/simple/{}".format(project)
+    url = f"https://pypi.org/simple/{project}"
     data = requests.get(url).content
     doc = html5lib.parse(data, namespaceHTMLElements=False)
     for i in doc.findall(".//a"):
@@ -120,7 +120,7 @@ class PyPIProvider(ExtrasProvider):
         return tuple(sorted(requirement_or_candidate.extras))
 
     def get_base_requirement(self, candidate):
-        return Requirement("{}=={}".format(candidate.name, candidate.version))
+        return Requirement(f"{candidate.name}=={candidate.version}")
 
     def get_preference(self, identifier, resolutions, candidates, information):
         return sum(1 for _ in candidates[identifier])

--- a/examples/reporter_demo.py
+++ b/examples/reporter_demo.py
@@ -26,14 +26,14 @@ third 3.0.0
 """
 
 
-class Requirement(namedtuple("Requirement", "name specifier")):  # noqa
+class Requirement(namedtuple("Requirement", "name specifier")):
     def __repr__(self):
         return "<Requirement({name}{specifier})>".format(
             name=self.name, specifier=self.specifier
         )
 
 
-class Candidate(namedtuple("Candidate", "name version")):  # noqa
+class Candidate(namedtuple("Candidate", "name version")):
     def __repr__(self):
         return "<{name}=={version}>".format(
             name=self.name, version=self.version

--- a/examples/reporter_demo.py
+++ b/examples/reporter_demo.py
@@ -28,16 +28,12 @@ third 3.0.0
 
 class Requirement(namedtuple("Requirement", "name specifier")):
     def __repr__(self):
-        return "<Requirement({name}{specifier})>".format(
-            name=self.name, specifier=self.specifier
-        )
+        return f"<Requirement({self.name}{self.specifier})>"
 
 
 class Candidate(namedtuple("Candidate", "name version")):
     def __repr__(self):
-        return "<{name}=={version}>".format(
-            name=self.name, version=self.version
-        )
+        return f"<{self.name}=={self.version}>"
 
 
 def splitstrip(s, parts):

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ def lint(session):
 
     session.run("black", "--check", ".")
     session.run("isort", ".")
-    session.run("flake8", ".")
+    session.run("ruff", "check", ".")
     session.run("mypy", "src", "tests")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ line-length = 88
 
 [tool.ruff.lint]
 select = ["C","E","F","W","B","RUF","PLE","PLW"]
-ignore = ["E203", "F401", "PLW2901"]
+ignore = ["E203", "PLW2901"]
 exclude = [
 	".git",
 	".venv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,7 @@ Homepage = "https://github.com/sarugaku/resolvelib"
 [project.optional-dependencies]
 lint = [
     "black==23.12.1",
-    "flake8",
-    "Flake8-pyproject",
+    "ruff",
     "isort",
     "mypy",
     "types-requests",
@@ -92,10 +91,12 @@ directory = 'trivial'
 name = 'Trivial Changes'
 showcontent = false
 
-[tool.flake8]
-max-line-length = 88
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
 select = ["C","E","F","W","B"]
-ignore = ["E203", "W503", "F401"]
+ignore = ["E203", "F401"]
 exclude = [
 	".git",
 	".venv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ showcontent = false
 line-length = 88
 
 [tool.ruff.lint]
-select = ["C","E","F","W","B"]
+select = ["C","E","F","W","B","RUF"]
 ignore = ["E203", "F401"]
 exclude = [
 	".git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,8 @@ showcontent = false
 line-length = 88
 
 [tool.ruff.lint]
-select = ["C","E","F","W","B","RUF"]
-ignore = ["E203", "F401"]
+select = ["C","E","F","W","B","RUF","PLE","PLW"]
+ignore = ["E203", "F401", "PLW2901"]
 exclude = [
 	".git",
 	".venv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ line-length = 88
 
 [tool.ruff.lint]
 select = ["C","E","F","W","B","RUF","PLE","PLW"]
-ignore = ["E203", "PLW2901"]
+ignore = ["PLW2901"]
 exclude = [
 	".git",
 	".venv",

--- a/src/resolvelib/compat/collections_abc.py
+++ b/src/resolvelib/compat/collections_abc.py
@@ -1,6 +1,0 @@
-__all__ = ["Mapping", "Sequence"]
-
-try:
-    from collections.abc import Mapping, Sequence
-except ImportError:
-    from collections import Mapping, Sequence

--- a/src/resolvelib/compat/collections_abc.pyi
+++ b/src/resolvelib/compat/collections_abc.pyi
@@ -1,1 +1,0 @@
-from collections.abc import Mapping, Sequence

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -109,8 +109,8 @@ class Resolution(Generic[RT, CT, KT]):
     def state(self) -> State[RT, CT, KT]:
         try:
             return self._states[-1]
-        except IndexError:
-            raise AttributeError("state")
+        except IndexError as e:
+            raise AttributeError("state") from e
 
     def _push_new_state(self) -> None:
         """Push a new state into history.
@@ -421,7 +421,7 @@ class Resolution(Generic[RT, CT, KT]):
             try:
                 self._add_to_criteria(self.state.criteria, r, parent=None)
             except RequirementsConflicted as e:
-                raise ResolutionImpossible(e.criterion.information)
+                raise ResolutionImpossible(e.criterion.information) from e
 
         # The root state is saved as a sentinel so the first ever pin can have
         # something to backtrack to if it fails. The root state is basically

--- a/src/resolvelib/resolvers.py
+++ b/src/resolvelib/resolvers.py
@@ -269,6 +269,41 @@ class Resolution(Generic[RT, CT, KT]):
         # end, signal for backtracking.
         return causes
 
+    def _patch_criteria(
+        self, incompatibilities_from_broken: list[tuple[KT, list[CT]]]
+    ) -> bool:
+        # Create a new state from the last known-to-work one, and apply
+        # the previously gathered incompatibility information.
+        for k, incompatibilities in incompatibilities_from_broken:
+            if not incompatibilities:
+                continue
+            try:
+                criterion = self.state.criteria[k]
+            except KeyError:
+                continue
+            matches = self._p.find_matches(
+                identifier=k,
+                requirements=IteratorMapping(
+                    self.state.criteria,
+                    operator.methodcaller("iter_requirement"),
+                ),
+                incompatibilities=IteratorMapping(
+                    self.state.criteria,
+                    operator.attrgetter("incompatibilities"),
+                    {k: incompatibilities},
+                ),
+            )
+            candidates: IterableView[CT] = build_iter_view(matches)
+            if not candidates:
+                return False
+            incompatibilities.extend(criterion.incompatibilities)
+            self.state.criteria[k] = Criterion(
+                candidates=candidates,
+                information=list(criterion.information),
+                incompatibilities=incompatibilities,
+            )
+        return True
+
     def _backjump(self, causes: list[RequirementInformation[RT, CT]]) -> bool:
         """Perform backjumping.
 
@@ -347,41 +382,8 @@ class Resolution(Generic[RT, CT, KT]):
             # Also mark the newly known incompatibility.
             incompatibilities_from_broken.append((name, [candidate]))
 
-            # Create a new state from the last known-to-work one, and apply
-            # the previously gathered incompatibility information.
-            def _patch_criteria() -> bool:
-                for k, incompatibilities in incompatibilities_from_broken:
-                    if not incompatibilities:
-                        continue
-                    try:
-                        criterion = self.state.criteria[k]
-                    except KeyError:
-                        continue
-                    matches = self._p.find_matches(
-                        identifier=k,
-                        requirements=IteratorMapping(
-                            self.state.criteria,
-                            operator.methodcaller("iter_requirement"),
-                        ),
-                        incompatibilities=IteratorMapping(
-                            self.state.criteria,
-                            operator.attrgetter("incompatibilities"),
-                            {k: incompatibilities},
-                        ),
-                    )
-                    candidates: IterableView[CT] = build_iter_view(matches)
-                    if not candidates:
-                        return False
-                    incompatibilities.extend(criterion.incompatibilities)
-                    self.state.criteria[k] = Criterion(
-                        candidates=candidates,
-                        information=list(criterion.information),
-                        incompatibilities=incompatibilities,
-                    )
-                return True
-
             self._push_new_state()
-            success = _patch_criteria()
+            success = self._patch_criteria(incompatibilities_from_broken)
 
             # It works! Let's work on this new state.
             if success:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from resolvelib import BaseReporter

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -146,8 +146,7 @@ def _clean_identifier(s):
 def _iter_resolved(dependencies):
     for entry in dependencies:
         yield (entry["name"], Version(entry["version"]))
-        for sub in _iter_resolved(entry["dependencies"]):
-            yield sub
+        yield from _iter_resolved(entry["dependencies"])
 
 
 class CocoaPodsInputProvider(AbstractProvider):

--- a/tests/functional/python/py2index.py
+++ b/tests/functional/python/py2index.py
@@ -31,13 +31,10 @@ import sys
 import urllib.parse
 from typing import (
     Dict,
-    FrozenSet,
     Iterable,
     Iterator,
     List,
     NamedTuple,
-    Optional,
-    Set,
     Tuple,
     Union,
 )

--- a/tests/functional/python/py2index.py
+++ b/tests/functional/python/py2index.py
@@ -121,8 +121,8 @@ def get_output_path(path: pathlib.Path, overwrite: bool) -> pathlib.Path:
 def _parse_tag(s: str) -> FrozenSet[packaging.tags.Tag]:
     try:
         return packaging.tags.parse_tag(s)
-    except ValueError:
-        raise ValueError(f"invalid tag {s!r}")
+    except ValueError as e:
+        raise ValueError(f"invalid tag {s!r}") from e
 
 
 @dataclasses.dataclass()

--- a/tests/functional/python/py2index.py
+++ b/tests/functional/python/py2index.py
@@ -64,7 +64,7 @@ def _parse_python_version(s: str) -> PythonVersion:
     return (int(major),)
 
 
-def _parse_output_path(s: str) -> Optional[pathlib.Path]:
+def _parse_output_path(s: str) -> pathlib.Path | None:
     if s == "-":
         return None
     if os.sep in s or (os.altsep and os.altsep in s):
@@ -72,7 +72,7 @@ def _parse_output_path(s: str) -> Optional[pathlib.Path]:
     return pathlib.Path(__file__).with_name("inputs").joinpath("index", s)
 
 
-def parse_args(args: Optional[List[str]]) -> argparse.Namespace:
+def parse_args(args: list[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "package_names",
@@ -118,7 +118,7 @@ def get_output_path(path: pathlib.Path, overwrite: bool) -> pathlib.Path:
     return path
 
 
-def _parse_tag(s: str) -> FrozenSet[packaging.tags.Tag]:
+def _parse_tag(s: str) -> frozenset[packaging.tags.Tag]:
     try:
         return packaging.tags.parse_tag(s)
     except ValueError as e:
@@ -128,14 +128,14 @@ def _parse_tag(s: str) -> FrozenSet[packaging.tags.Tag]:
 @dataclasses.dataclass()
 class WheelMatcher:
     required_python: packaging.version.Version
-    tags: Dict[packaging.tags.Tag, int]
+    tags: dict[packaging.tags.Tag, int]
 
     @classmethod
     def compatible_with(
         cls,
         python_version: PythonVersion,
-        impl: Optional[str],
-        plats: Optional[List[str]],
+        impl: str | None,
+        plats: list[str] | None,
     ) -> WheelMatcher:
         required_python = packaging.version.Version(
             ".".join(str(v) for v in python_version)
@@ -148,7 +148,7 @@ class WheelMatcher:
         tags = {t: i for i, t in enumerate(tag_it)}
         return cls(required_python, tags)
 
-    def rank(self, tag: str, requires_python: Optional[str]) -> Optional[int]:
+    def rank(self, tag: str, requires_python: str | None) -> int | None:
         if requires_python:
             spec = packaging.specifiers.SpecifierSet(requires_python)
             if self.required_python not in spec:
@@ -197,7 +197,7 @@ class HttpFile:
         return self._offset
 
 
-def _parse_wheel_name(rest: str) -> Tuple[str, str, str]:
+def _parse_wheel_name(rest: str) -> tuple[str, str, str]:
     name, rest = rest.split("-", 1)
     version, x, y, z = rest.rsplit("-", 3)
     return name, version, f"{x}-{y}-{z}"
@@ -205,7 +205,7 @@ def _parse_wheel_name(rest: str) -> Tuple[str, str, str]:
 
 class PackageEntry(NamedTuple):
     version: str
-    dependencies: List[str]
+    dependencies: list[str]
 
 
 DistListMapping = Dict[str, List[Tuple[int, str]]]
@@ -213,11 +213,11 @@ DistListMapping = Dict[str, List[Tuple[int, str]]]
 
 @dataclasses.dataclass()
 class Finder:
-    index_urls: List[str]
+    index_urls: list[str]
     matcher: WheelMatcher
     session: requests.Session
 
-    def collect_best_metadta_urls(self, name: str) -> Dict[str, str]:
+    def collect_best_metadta_urls(self, name: str) -> dict[str, str]:
         all_dists: DistListMapping = collections.defaultdict(list)
         for index_url in self.index_urls:
             res = requests.get(f"{index_url}/{name}")
@@ -259,12 +259,12 @@ class Finder:
             http_file = HttpFile(url, self.session)
             parser = email.parser.BytesParser()
             data = parser.parsebytes(http_file.read(), headersonly=True)
-            dependencies: List[str] = data.get_all("Requires-Dist", [])
+            dependencies: list[str] = data.get_all("Requires-Dist", [])
             yield PackageEntry(version, dependencies)
 
     def process_package_entry(
         self, name: str, entry: PackageEntry
-    ) -> Optional[Set[str]]:
+    ) -> set[str] | None:
         more = set()
         for dep in entry.dependencies:
             try:
@@ -283,10 +283,10 @@ class Finder:
     def find(self, package_names: Iterable[str]) -> dict:
         data = {}
         while package_names:
-            more: Set[str] = set()
+            more: set[str] = set()
             logger.info("Discovering %s", ", ".join(package_names))
             for name in package_names:
-                entries: Dict[str, dict] = {}
+                entries: dict[str, dict] = {}
                 for e in self.iter_package_entries(name):
                     result = self.process_package_entry(name, e)
                     if result is None:
@@ -298,10 +298,10 @@ class Finder:
         return data
 
 
-def main(args: Optional[List[str]]) -> int:
+def main(args: list[str] | None) -> int:
     options = parse_args(args)
     if not options.output:
-        output_path: Optional[pathlib.Path] = None
+        output_path: pathlib.Path | None = None
     else:
         output_path = get_output_path(options.output, options.overwrite)
     matcher = WheelMatcher.compatible_with(

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -72,7 +72,7 @@ class PythonInputProvider(AbstractProvider):
         name = packaging.utils.canonicalize_name(requirement_or_candidate.name)
         if requirement_or_candidate.extras:
             extras_str = ",".join(sorted(requirement_or_candidate.extras))
-            return "{}[{}]".format(name, extras_str)
+            return f"{name}[{extras_str}]"
         return name
 
     def get_preference(
@@ -112,7 +112,7 @@ class PythonInputProvider(AbstractProvider):
     def _iter_dependencies(self, candidate):
         name = packaging.utils.canonicalize_name(candidate.name)
         if candidate.extras:
-            r = "{}=={}".format(name, candidate.version)
+            r = f"{name}=={candidate.version}"
             yield packaging.requirements.Requirement(r)
         for r in self.index[name][str(candidate.version)]["dependencies"]:
             requirement = packaging.requirements.Requirement(r)


### PR DESCRIPTION
This PR is to switch from flake8 to ruff as the linter, the motivation here is two fold:

 * flake8 E704 is not compatible with the black 2024 style - and flake8 maintainers seem uninterested in making this rule compatible with this common style, whereas ruff maintainers seem to be eager to keep in-line with modern black style
 * there are many additional rules that come with ruff that can be turned on automatically or easily run manually, and high pace of adding new ones

I may have gone overboard with this PR, let me know if I should make it a minimal transition, but I have split it out hopefully into easily digestible commits.

My biggest concern is https://github.com/sarugaku/resolvelib/commit/949e6120fbc7b714fde71c2118a96d085a69acb2 which moves `_patch_criteria` into it's own method, rather than an inline function. This personally reads better to me, but I am not a frequent programmer of algorithms that use functional programming. Happy to revert. 
