### PR TITLE
Update to Black 2024 style

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ Homepage = "https://github.com/sarugaku/resolvelib"
 
 [project.optional-dependencies]
 lint = [
+    "black~=24.0",
     "ruff",
     "mypy",
     "types-requests",

--- a/tests/functional/cocoapods/test_resolvers_cocoapods.py
+++ b/tests/functional/cocoapods/test_resolvers_cocoapods.py
@@ -231,12 +231,14 @@ XFAIL_CASES = {
 
 @pytest.fixture(
     params=[
-        pytest.param(
-            os.path.join(CASE_DIR, n),
-            marks=pytest.mark.xfail(strict=True, reason=XFAIL_CASES[n]),
+        (
+            pytest.param(
+                os.path.join(CASE_DIR, n),
+                marks=pytest.mark.xfail(strict=True, reason=XFAIL_CASES[n]),
+            )
+            if n in XFAIL_CASES
+            else os.path.join(CASE_DIR, n)
         )
-        if n in XFAIL_CASES
-        else os.path.join(CASE_DIR, n)
         for n in CASE_NAMES
     ],
     ids=[n[:-5] for n in CASE_NAMES],

--- a/tests/functional/python/test_resolvers_python.py
+++ b/tests/functional/python/test_resolvers_python.py
@@ -135,12 +135,14 @@ XFAIL_CASES = {
 
 @pytest.fixture(
     params=[
-        pytest.param(
-            os.path.join(CASE_DIR, n),
-            marks=pytest.mark.xfail(strict=True, reason=XFAIL_CASES[n]),
+        (
+            pytest.param(
+                os.path.join(CASE_DIR, n),
+                marks=pytest.mark.xfail(strict=True, reason=XFAIL_CASES[n]),
+            )
+            if n in XFAIL_CASES
+            else os.path.join(CASE_DIR, n)
         )
-        if n in XFAIL_CASES
-        else os.path.join(CASE_DIR, n)
         for n in CASE_NAMES
     ],
     ids=[n[:-5] for n in CASE_NAMES],


### PR DESCRIPTION
Black updates their style once per year, following their stability policy I am using `black~=24.0` as the requirement: https://black.readthedocs.io/en/latest/the_black_code_style/index.html#stability-policy. Some time next year this can be updated to `black~=25.0`.