### PR TITLE
Enable isort via ruff

### DIFF
--- a/news/165.bugfix
+++ b/news/165.bugfix
@@ -1,0 +1,1 @@
+Enable isorting via ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,11 @@ name = 'Trivial Changes'
 showcontent = false
 
 [tool.ruff]
+src = ["src"]
 line-length = 88
 
 [tool.ruff.lint]
-select = ["C","E","F","W","B","RUF","PLE","PLW"]
+select = ["C","E","F","W","B","RUF","PLE","PLW","I"]
 ignore = ["PLW2901"]
 exclude = [
 	".git",
@@ -95,9 +96,6 @@ exclude = [
 	"dist",
 	"*.pyi"
 ]
-
-[tool.ruff.lint.isort]
-known-first-party = ["resolvelib"]
 
 [tool.mypy]
 warn_unused_configs = true


### PR DESCRIPTION
This enables the ruff isort rules (I) and sets the location of the projects source, such that the known-first-party ruff isort config is not needed.