### PR TITLE
Guard type hinting via ruff

### DIFF
--- a/news/166.feature
+++ b/news/166.feature
@@ -1,0 +1,2 @@
+Enable automatic TYPE_CHECK guarding for imports only used for type hinting
+via ruff rules TCH and FA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ src = ["src"]
 line-length = 88
 
 [tool.ruff.lint]
-select = ["C","E","F","W","B","RUF","PLE","PLW","I"]
+select = ["C","E","F","W","B","RUF","PLE","PLW","I","TCH","FA"]
 ignore = ["PLW2901"]
 exclude = [
 	".git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,10 +80,11 @@ name = 'Trivial Changes'
 showcontent = false
 
 [tool.ruff]
+src = ["src"]
 line-length = 88
 
 [tool.ruff.lint]
-select = ["C","E","F","W","B","RUF","PLE","PLW"]
+select = ["C","E","F","W","B","RUF","PLE","PLW","I"]
 ignore = ["PLW2901"]
 exclude = [
 	".git",
@@ -95,9 +96,6 @@ exclude = [
 	"dist",
 	"*.pyi"
 ]
-
-[tool.ruff.lint.isort]
-known-first-party = ["resolvelib"]
 
 [tool.mypy]
 warn_unused_configs = true

--- a/src/resolvelib/resolvers/abstract.py
+++ b/src/resolvelib/resolvers/abstract.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import collections
 from typing import TYPE_CHECKING, Any, Generic, Iterable, Mapping, NamedTuple
 
-from ..providers import AbstractProvider
-from ..reporters import BaseReporter
 from ..structs import CT, KT, RT, DirectedGraph
-from .criterion import Criterion
 
 if TYPE_CHECKING:
 
+    from ..providers import AbstractProvider
+    from ..reporters import BaseReporter
+    from .criterion import Criterion
     class Result(NamedTuple, Generic[RT, CT, KT]):
         mapping: Mapping[KT, CT]
         graph: DirectedGraph[KT | None]

--- a/src/resolvelib/resolvers/abstract.py
+++ b/src/resolvelib/resolvers/abstract.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING, Any, Generic, Iterable, Mapping, NamedTuple
 from ..structs import CT, KT, RT, DirectedGraph
 
 if TYPE_CHECKING:
-
     from ..providers import AbstractProvider
     from ..reporters import BaseReporter
     from .criterion import Criterion
+
     class Result(NamedTuple, Generic[RT, CT, KT]):
         mapping: Mapping[KT, CT]
         graph: DirectedGraph[KT | None]

--- a/src/resolvelib/resolvers/exceptions.py
+++ b/src/resolvelib/resolvers/exceptions.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Collection, Generic
+from typing import TYPE_CHECKING, Collection, Generic
 
 from ..structs import CT, RT, RequirementInformation
-from .criterion import Criterion
+
+if TYPE_CHECKING:
+    from .criterion import Criterion
 
 
 class ResolverException(Exception):

--- a/src/resolvelib/resolvers/resolution.py
+++ b/src/resolvelib/resolvers/resolution.py
@@ -5,8 +5,6 @@ import itertools
 import operator
 from typing import TYPE_CHECKING, Collection, Generic, Iterable, Mapping
 
-from ..providers import AbstractProvider
-from ..reporters import BaseReporter
 from ..structs import (
     CT,
     KT,
@@ -29,7 +27,8 @@ from .exceptions import (
 )
 
 if TYPE_CHECKING:
-    from ..providers import Preference
+    from ..providers import AbstractProvider, Preference
+    from ..reporters import BaseReporter
 
 
 def _build_result(state: State[RT, CT, KT]) -> Result[RT, CT, KT]:

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -13,7 +13,11 @@ from resolvelib import (
     InconsistentCandidate,
     ResolutionImpossible,
 )
-from resolvelib.resolvers import Resolution, Resolver
+from resolvelib.resolvers import (
+    RequirementsConflicted,
+    Resolution,
+    Resolver,
+)
 
 if TYPE_CHECKING:
     from typing import Iterable, Mapping
@@ -21,7 +25,6 @@ if TYPE_CHECKING:
     from resolvelib.resolvers import (
         Criterion,
         RequirementInformation,
-        RequirementsConflicted,
     )
 
 


### PR DESCRIPTION
This PR builds on top of https://github.com/sarugaku/resolvelib/pull/165

I notice it's a common pattern in this library, and one I prefer, to use `from __future__ import annotations` and guard type hint only imports behind `if TYPE_CHECKING`, this can be implemented automatically with ruff using: `required-imports = ["from __future__ import annotations"]` with the isort rules and the TCH rules: https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch (namely TCH001, TCH002, and TCH003).

I updated the config than then just ran a series of ruff --fix commands for the remaining commits (I have documented them to be clear).

Let me know if this is to your liking or not.