### PR TITLE
Add news fragments

### DIFF
--- a/news/129.feature
+++ b/news/129.feature
@@ -1,0 +1,1 @@
+Declare supported Python version support ">= 3.7" in dist meta

--- a/news/133.feature
+++ b/news/133.feature
@@ -1,0 +1,1 @@
+Improve exception chaining when ResolutionImpossible raises during backjumping

--- a/news/135.feature
+++ b/news/135.feature
@@ -1,0 +1,1 @@
+Switch from pyi files to modern annotations based type hinting

--- a/news/136.bugfix
+++ b/news/136.bugfix
@@ -1,0 +1,1 @@
+Fix example reporter_demo `get_preference` method which requires arg `backtrack_causes`

--- a/news/138.bugfix
+++ b/news/138.bugfix
@@ -1,0 +1,1 @@
+Clarify the docstrings for `providers.py`

--- a/news/141.feature
+++ b/news/141.feature
@@ -1,0 +1,1 @@
+In tests the commentjson test dependency with re.sub

--- a/news/143.feature
+++ b/news/143.feature
@@ -1,0 +1,1 @@
+Deduplicate failure causes to save memory and reduce backtracking overhead

--- a/news/150.bugfix
+++ b/news/150.bugfix
@@ -1,0 +1,1 @@
+Pin Black version for linting to prevent CI failures

--- a/news/152.bugfix
+++ b/news/152.bugfix
@@ -1,0 +1,2 @@
+In unexpected situation where broken_state.mapping is empty, stop backtracking,
+and continue resolution (rather than throwing ResolutionImpossible)

--- a/news/153.feature
+++ b/news/153.feature
@@ -1,0 +1,1 @@
+Run tests against Python 3.12, 3.13, and use latest version of CI dependencies

--- a/news/155.bugfix
+++ b/news/155.bugfix
@@ -1,0 +1,2 @@
+During backtracking check if the current broken state is an incompatible dependency,
+if not stop backtracking and continue resolution.

--- a/news/156.feature
+++ b/news/156.feature
@@ -1,0 +1,1 @@
+Update py2ndex script to use metadata files, skip 404, and support PEP 723

--- a/news/157.feature
+++ b/news/157.feature
@@ -1,0 +1,1 @@
+Replace setuptools.cfg and mypy.ini with pyproject.toml

--- a/news/158.feature
+++ b/news/158.feature
@@ -1,0 +1,2 @@
+Add tests type "unvisited" to functional Python tests to ensure backjumping
+is correctly skipping candidates

--- a/news/160.feature
+++ b/news/160.feature
@@ -1,0 +1,1 @@
+Switch from flake8 to ruff for linting

--- a/news/162.bugfix
+++ b/news/162.bugfix
@@ -1,0 +1,1 @@
+ Separate AbstractResolver and Resolver into different modules

--- a/news/163.bugfix
+++ b/news/163.bugfix
@@ -1,0 +1,1 @@
+Separate resolvers into different modules

--- a/news/164.bugfix
+++ b/news/164.bugfix
@@ -1,0 +1,1 @@
+Export criterion in resolvers to keep compatibility


### PR DESCRIPTION
Never done this before, but following up on https://github.com/sarugaku/resolvelib/issues/159#issuecomment-2262070162

I used this script to just pre-populate the NEWS directory and then went through each PR:

```bash
GITHUB_TOKEN="xxx"
git log --pretty="%h - %s" --after="2023-03-09" --grep 'Merge pull request' | grep -oP '#\d+' | grep -oP '\d+' | while read pr; do
    curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/sarugaku/resolvelib/pulls/$pr | jq -r '.title' > news/${pr}.bugfix
done
```

Not sure what the style guide is here, just tried my best, can fix anything up as you wish.