### PR TITLE
Drop `wheel` from direct build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ release = [
 ]
 
 [build-system]
-requires = ['setuptools>=62', 'wheel']
+requires = ["setuptools >= 62"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
It was never necessary. In the past, `setuptools` would pull it in through the PEP 517 hook, only when building the wheels. During PyCon 2024, though, `wheel` moved into the `setuptools`' codebase and so it's always bundled now, in the modern versions.