### PR TITLE
Display PyPI URL on GH UI when releasing from GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,9 @@ jobs:
     name: Publish released package to pypi.org
     permissions:
       id-token: write
-    environment: release
+    environment:
+      name: release
+      url: https://pypi.org/project/resolvelib/${{ github.ref_name }}
     runs-on: ubuntu-latest
     needs: build-package
 


### PR DESCRIPTION
This patch adds a clickable link to GitHub web interfaces like https://github.com/sarugaku/resolvelib/actions/runs/11604423758 and https://github.com/sarugaku/resolvelib/deployments/release.