### PR TITLE
Configure `setuptools` to produce `py3`-tagged wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ find = {where = ["src"], namespaces = false}
 version = {attr = "resolvelib.__version__"}
 
 [tool.distutils.bdist_wheel]
-universal = true
+universal = false  # `py3` only tag
 
 [tool.towncrier]
 package = 'resolvelib'


### PR DESCRIPTION
Previously, the wheels published to PyPI were being tagged with `py2.py3` implying Python 2 support, despite having `Require-Python: >= 3.7` in the core metadata: https://pypi.org/project/resolvelib/1.1.0/#files. This patch fixes that, forcing the build tool chain to produce wheels only having the `py3` tag in their filenames.