### PR TITLE
New disjoint method for provider

### DIFF
--- a/src/resolvelib/providers.py
+++ b/src/resolvelib/providers.py
@@ -194,3 +194,30 @@ class AbstractProvider(Generic[RT, CT, KT]):
             Iterable[KT]: A non-empty subset of `identifiers`.
         """
         return identifiers
+
+    def disjoint(
+        self, backtrack_causes: Sequence[RequirementInformation[RT, CT]]
+    ) -> Sequence[RequirementInformation[RT, CT]]:
+        """Filter backtrack causes to retain only disjoint instances.
+
+        Given a sequence of backtrack causes, return those that are disjoint.
+        This filtered sequence will attached to the resolution state, passed to
+        the provider methods `get_preference` and `narrow_requirement_selection`,
+        and the reporter method `resolving_conflicts`.
+
+        :param backtrack_causes: A sequence of *requirement information* that are
+            the requirements causing the resolver to most recently
+            backtrack.
+
+        A *requirement information* instance is a named tuple with two members:
+
+        * ``requirement`` specifies a requirement contributing to the current
+          list of candidates.
+        * ``parent`` specifies the candidate that provides (is depended on for)
+          the requirement, or ``None`` to indicate a root requirement.
+
+        Returns:
+            Sequence[RequirementInformation[RT, CT]]: A subset of at least two
+            disjoint `backtrack_causes`.
+        """
+        return backtrack_causes


### PR DESCRIPTION
Fixes https://github.com/sarugaku/resolvelib/issues/171

This allows the provider to implement a method to determine the causes which are disjoint, this has a number of advantages:

1. It reduces the number of causes saved to the state
2. If the provider uses `backtrack_causes` in `get_preference` or `narrow_requirement_selection` they will be the disjoint causes allowing the provider to not have to iterate through as many causes or re-implement figuring out disjoint causes on every different method call
3. For `ResolutionImpossible` errors the disjoint causes will naturally be returned 

If the provider does not implement a `disjoint` method then there is no behavior change, so this PR should be completely backwards compatible.