### PR TITLE
Fix pypi project page link on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,4 +87,4 @@ A Requirement should specify two things: a Package, and a Specifier.
 Contributing
 ============
 
-Please see `developer documentation <./DEVELOPMENT.rst>`__.
+Please see `developer documentation <https://github.com/sarugaku/resolvelib/blob/main/DEVELOPMENT.rst>`__.


### PR DESCRIPTION
This should fix the link on https://pypi.org/project/resolvelib/

Is there a better way to fix this link?