### PR TITLE
Fix ruff linting errors

### DIFF
--- a/src/resolvelib/__init__.py
+++ b/src/resolvelib/__init__.py
@@ -1,14 +1,14 @@
 __all__ = [
-    "__version__",
     "AbstractProvider",
     "AbstractResolver",
     "BaseReporter",
     "InconsistentCandidate",
-    "Resolver",
     "RequirementsConflicted",
     "ResolutionError",
     "ResolutionImpossible",
     "ResolutionTooDeep",
+    "Resolver",
+    "__version__",
 ]
 
 __version__ = "1.1.1dev0"

--- a/src/resolvelib/resolvers/__init__.py
+++ b/src/resolvelib/resolvers/__init__.py
@@ -13,15 +13,15 @@ from .resolution import Resolution, Resolver
 
 __all__ = [
     "AbstractResolver",
+    "Criterion",
     "InconsistentCandidate",
-    "Resolver",
-    "Resolution",
+    "RequirementInformation",
     "RequirementsConflicted",
+    "Resolution",
     "ResolutionError",
     "ResolutionImpossible",
     "ResolutionTooDeep",
-    "RequirementInformation",
+    "Resolver",
     "ResolverException",
     "Result",
-    "Criterion",
 ]


### PR DESCRIPTION
Ruff stabalized auto sorting of `__all__` in 0.8.0, and all `RUF` rules are on by default.

This seems fairly harmless.