### PR TITLE
Drop support for Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
           - "3.11"
           - "3.10"
           - "3.9"
-          - "3.8"
-          - "3.7"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/news/187.significant.rst
+++ b/news/187.significant.rst
@@ -1,0 +1,1 @@
+Drop support for EOL Python versions 3.7 and 3.8.

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,7 +20,7 @@ def lint(session):
     session.run("mypy", "src", "tests")
 
 
-@nox.session(python=["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7"])
+@nox.session(python=["3.13", "3.12", "3.11", "3.10", "3.9"])
 def tests(session):
     session.install(".[test]")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Tzu-ping Chung", email = "uranusjr@gmail.com"},
 ]
 dependencies = []
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 readme = "README.rst"
 license = {text = "ISC License"}
 keywords = ["dependency", "resolution"]


### PR DESCRIPTION
GitHub Action does not support them anymore. Let’s just drop it and 3.8 since they are EOL anyway.