### PR TITLE
Optimistic backjumping with cutoff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ exclude = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 12
+max-complexity = 20
 
 [tool.mypy]
 warn_unused_configs = true

--- a/tests/functional/python/inputs/case/backjump-test-3.json
+++ b/tests/functional/python/inputs/case/backjump-test-3.json
@@ -1,0 +1,18 @@
+{
+	"index": "backjump-test-3",
+	"requested": [
+		"a==1",
+		"b",
+		"c"
+	],
+	"resolved": {
+		"a": "1",
+		"b": "1",
+		"c": "2",
+		"d": "1"
+	},
+	"unvisited": {
+		"c": ["1"]
+	},
+	"needs_optimistic": true
+}

--- a/tests/functional/python/inputs/case/backjump-test-4.json
+++ b/tests/functional/python/inputs/case/backjump-test-4.json
@@ -1,0 +1,24 @@
+{
+	"index": "backjump-test-4",
+	"requested": [
+		"a==1",
+		"b",
+		"c",
+		"e",
+		"f"
+	],
+	"resolved": {
+		"a": "1",
+		"b": "1",
+		"c": "2",
+		"d": "1",
+		"e": "2",
+		"f": "2"
+	},
+	"unvisited": {
+		"c": ["1"],
+		"e": ["1"],
+		"f": ["1"]
+	},
+	"needs_optimistic": true
+}

--- a/tests/functional/python/inputs/index/backjump-test-3.json
+++ b/tests/functional/python/inputs/index/backjump-test-3.json
@@ -1,0 +1,43 @@
+{
+    "a": {
+        "1": {
+            "dependencies": []
+        },
+        "2": {
+            "dependencies": []
+        }
+    },
+    "b": {
+        "2": {
+            "dependencies": [
+                "d==2"
+            ]
+        },
+        "1": {
+            "dependencies": [
+                "d==1"
+            ]
+        }
+    },
+    "c": {
+        "1": {
+            "dependencies": []
+        },
+        "2": {
+            "dependencies": []
+        }
+    },
+    "d": {
+        "2": {
+            "dependencies": [
+                "a==2"
+            ]
+        },
+        "1": {
+            "dependencies": [
+                "a==1"
+            ]
+        }
+    },
+	"needs_optimistic": true
+}

--- a/tests/functional/python/inputs/index/backjump-test-4.json
+++ b/tests/functional/python/inputs/index/backjump-test-4.json
@@ -1,0 +1,58 @@
+{
+    "a": {
+        "1": {
+            "dependencies": []
+        },
+        "2": {
+            "dependencies": []
+        }
+    },
+    "b": {
+        "2": {
+            "dependencies": [
+                "d==2"
+            ]
+        },
+        "1": {
+            "dependencies": [
+                "d==1"
+            ]
+        }
+    },
+    "c": {
+        "1": {
+            "dependencies": []
+        },
+        "2": {
+            "dependencies": []
+        }
+    },
+    "d": {
+        "2": {
+            "dependencies": [
+                "a==2"
+            ]
+        },
+        "1": {
+            "dependencies": [
+                "a==1"
+            ]
+        }
+    },
+    "e": {
+        "1": {
+            "dependencies": []
+        },
+        "2": {
+            "dependencies": []
+        }
+    },
+    "f": {
+        "1": {
+            "dependencies": []
+        },
+        "2": {
+            "dependencies": []
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/sarugaku/resolvelib/issues/180

This implements https://github.com/sarugaku/resolvelib/issues/180#issuecomment-2847584328 with a ratio of 10%.

10% is somewhat arbitrary, but the general idea is optimistic backtracking is supposed to be much faster than regular backtracking, and therefore if it is taking a significant amount of the remaining rounds left it is *probably* going down the wrong path. I tried several different numbers for different max rounds on real world and synthetic cases and found between 5% and 20% tended to work best.

While not intended to be changed I have made `_OPTIMISTIC_BACKJUMPING_RATIO` a global as an easy way for a knowledgeable motivated resolvelib user to pick a different ratio (in particular they may want to pick 0 or 1).

I have added additional tests that fail without optimistic backjumping (i.e. optimistic backjumping is able to skip over certain requirements that regular backjumping can not). I also test turning off optimistic backjumping to make sure all other tests pass without it.

(Note: I have collected recent problematic real world examples in https://github.com/pypa/pip/issues/13281 and have been documenting them in [problematic.toml](https://github.com/notatallshaw/Pip-Resolution-Scenarios-and-Benchmarks/blob/main/scenarios/problematic.toml)).
