### PR TITLE
Change `Mapping` to `dict` in resolution `Result` type annotations

### DIFF
--- a/src/resolvelib/resolvers/abstract.py
+++ b/src/resolvelib/resolvers/abstract.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import collections
-from typing import TYPE_CHECKING, Any, Generic, Iterable, Mapping, NamedTuple
+from typing import TYPE_CHECKING, Any, Generic, Iterable, NamedTuple
 
 from ..structs import CT, KT, RT, DirectedGraph
 
@@ -11,9 +11,9 @@ if TYPE_CHECKING:
     from .criterion import Criterion
 
     class Result(NamedTuple, Generic[RT, CT, KT]):
-        mapping: Mapping[KT, CT]
+        mapping: dict[KT, CT]
         graph: DirectedGraph[KT | None]
-        criteria: Mapping[KT, Criterion[RT, CT]]
+        criteria: dict[KT, Criterion[RT, CT]]
 
 else:
     Result = collections.namedtuple("Result", ["mapping", "graph", "criteria"])


### PR DESCRIPTION
`typing.Mapping` is a broad concept. The actual code just assigns `dict`s so `Result` should just use that.

I've been adding annotations to the calling side (`ansible-galaxy`) that uses `resolvelib` and hit this as I was trying to show that a function that returns `Resolver(...).resolve(...).mapping` produces a `dict`.