### PR TITLE
Convert license metadata to the PEP 639 format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ authors = [
 dependencies = []
 requires-python = ">=3.9"
 readme = "README.rst"
-license = {text = "ISC License"}
+license = "ISC"
+license-files = ["LICENSE"]
 keywords = ["dependency", "resolution"]
 classifiers = [
 	"Development Status :: 3 - Alpha",
 	"Intended Audience :: Developers",
-	"License :: OSI Approved :: ISC License (ISCL)",
 	"Operating System :: OS Independent",
 	"Programming Language :: Python :: 3",
 	"Topic :: Software Development :: Libraries :: Python Modules",
@@ -40,7 +40,7 @@ release = [
 ]
 
 [build-system]
-requires = ["setuptools >= 62"]
+requires = ["setuptools >= 77"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
The table form of `license` and license classifiers are now deprecated.