### PR TITLE
Fix sdist test include

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include CHANGELOG.rst LICENSE
 recursive-include src *.pyi py.typed
-recursive-include tests
+recursive-include tests *


### PR DESCRIPTION
There was an attempt to add full tests to sdist in #173, but it failed.