### PR TITLE
Increase _OPTIMISTIC_BACKJUMPING_RATIO from 0.1 to 0.2

### DIFF
--- a/src/resolvelib/resolvers/resolution.py
+++ b/src/resolvelib/resolvers/resolution.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from ..providers import AbstractProvider, Preference
     from ..reporters import BaseReporter
 
-_OPTIMISTIC_BACKJUMPING_RATIO: float = 0.1
+_OPTIMISTIC_BACKJUMPING_RATIO: float = 0.2
 
 
 def _build_result(state: State[RT, CT, KT]) -> Result[RT, CT, KT]:


### PR DESCRIPTION
## Problem

When the optimistic backjumping budget is exhausted before the resolver finds the conflict cause, the entire optimistic state is rolled back and optimistic mode is permanently disabled. At ratio=0.1, the budget (`int((max_rounds - start_round) * 0.1)`) is small enough that dependency graphs with several intermediate packages between the root cause and the conflict trigger consistently exhaust it — causing the resolver to pay the cost of both the failed aggressive attempt and the subsequent conservative re-resolution.

## Change

One line. The backjumping algorithm is unchanged — only the budget allocation for optimistic mode.

## Evaluation

Three synthetic dependency graphs were constructed using resolvelib's test provider pattern, each designed to exercise a different aspect of the aggressive/conservative backjumping tradeoff. Resolution was run deterministically at 9 ratio values (0.0, 0.05, 0.1, 0.15, 0.2, 0.3, 0.5, 0.8, 1.0). "Rounds" refers to the resolver's internal resolution loop iterations as reported by the reporter's `starting_round` callback.

| Scenario | Description | Ratio=0.0 | Ratio=0.1 (current) | Ratio=0.2 (proposed) |
|----------|-------------|-----------|---------------------|---------------------|
| A | 4 multi-version intermediaries between cause and conflict | 62 rounds | 21 rounds | 21 rounds |
| B | 8 single-version intermediaries | 33 rounds | 54 rounds | 33 rounds |
| C | 12 single-version intermediaries (triggers permanent disable) | 45 rounds | 66 rounds | 45 rounds |

In the three evaluated synthetic scenarios, changing `_OPTIMISTIC_BACKJUMPING_RATIO` from 0.1 to 0.2 reduced total resolution rounds from 141 to 99 (about 30%) by allowing optimistic mode to reach the conflict cause before exhausting its budget. In aggregate across these scenarios, 0.1 and 0.0 were nearly identical (141 vs 140 total rounds), but 0.1 showed mixed behavior by scenario: it matched the best result in Scenario A while regressing in Scenarios B and C when optimistic mode timed out and was permanently disabled.

**Evaluation environment:** Python 3.12.3, resolvelib HEAD, pytest 9.0.2.

## Test Results

All 88 tests pass. 6 xfailed (expected failures, unchanged from baseline).

## Risk

- **Worst case:** On dependency graphs where the optimistic jump overshoots, the resolver spends slightly more rounds in optimistic mode before the permanent-disable mechanism activates. The fallback behavior is identical — conservative mode takes over.
- **Reversibility:** Single constant. Trivially revertable.
- **Resolution outcomes:** Unchanged. The same packages are resolved in the same final state. Only the number of intermediate rounds differs.

## Scope

This change affects the budget calculation only. It does not change:
- The backjumping algorithm
- The optimistic/conservative decision logic
- The permanent-disable mechanism
- The state save/rollback behavior

The evaluation is limited to three synthetic scenarios. Real-world dependency graphs may behave differently. Among the evaluated ratio values, 0.2 was the smallest that avoided the observed budget-exhaustion regressions, and all values from 0.2 through 1.0 produced identical results in these scenarios.